### PR TITLE
Active filter

### DIFF
--- a/app/models/condition.coffee
+++ b/app/models/condition.coffee
@@ -49,6 +49,10 @@ Condition = DS.Model.extend(
 
   startDate: Em.computed('onsetDate', -> @get('onsetDate'))
   endDate: Em.computed('abatementDate', -> @get('abatementDate'))
+
+  active: (->
+    not @get('abatementDate')? or (@get('abatementDate') > new Date())
+  ).property('abatementDate')
 )
 
 `export default Condition`

--- a/app/models/medication-statement.coffee
+++ b/app/models/medication-statement.coffee
@@ -28,16 +28,20 @@
 
 MedicationStatement = DS.Model.extend
   identifier: DS.hasMany('identifier')
-  patient: DS.belongsTo('reference')
+  patient: DS.belongsTo('resource-reference')
   wasNotGiven: DS.attr('boolean')
-  reasonNotGiven: DS.hasMany('codeableConcept')
+  reasonNotGiven: DS.hasMany('codeable-concept')
   whenGiven: DS.belongsTo('period')
   medication: DS.belongsTo('medication', async: true)
-  device: DS.hasMany('reference')
+  device: DS.hasMany('resource-reference')
   dosage: DS.hasMany('dosage')
 
   startDate: Ember.computed('whenGiven', -> @get('whenGiven.start'))
   endDate: Ember.computed('whenGiven', -> @get('whenGiven.end'))
   text: Ember.computed('medication',  -> @get('medication.text'))
+
+  active: (->
+    not @get('period.end')? or (@get('period.end') > new Date())
+  ).property('period')
 
 `export default MedicationStatement`

--- a/app/models/medication-statement.coffee
+++ b/app/models/medication-statement.coffee
@@ -41,7 +41,7 @@ MedicationStatement = DS.Model.extend
   text: Ember.computed('medication',  -> @get('medication.text'))
 
   active: (->
-    not @get('period.end')? or (@get('period.end') > new Date())
-  ).property('period')
+    not @get('whenGiven.end')? or (@get('whenGiven.end') > new Date())
+  ).property('whenGiven.end')
 
 `export default MedicationStatement`

--- a/app/models/medication.coffee
+++ b/app/models/medication.coffee
@@ -30,7 +30,7 @@ Medication = DS.Model.extend
   name: DS.attr('string')
   code: DS.belongsTo('codeableConcept')
   isBrand: DS.attr('boolean')
-  manufacturer: DS.belongsTo('reference')
+  manufacturer: DS.belongsTo('resource-reference')
   kind: DS.attr('string')
 
   text: (->

--- a/app/models/patient.coffee
+++ b/app/models/patient.coffee
@@ -61,7 +61,7 @@ Patient = DS.Model.extend(
   ).property('risks')
 
   computedRisk: (->
-    riskTotal = @get('medications.length') + @get('conditions.length')
+    riskTotal = @get('activeMedications.length') + @get('activeConditions.length')
     if riskTotal > 6
       riskTotal = 6
     riskTotal
@@ -89,6 +89,7 @@ Patient = DS.Model.extend(
       Math.round(Math.random() * (92 - 65) + 65)
 
   activeMedications: Ember.computed.filterBy 'medications', 'active', true
+  activeConditions: Ember.computed.filterBy 'conditions', 'active', true
 
   inpatientAdmissions: Ember.computed.filter 'encounters', (item) ->
     is_inpatient = false

--- a/app/models/patient.coffee
+++ b/app/models/patient.coffee
@@ -158,23 +158,16 @@ Patient = DS.Model.extend(
     @get("medications").forEach (ev) =>
       console.log ev.get('medication')
       events.pushObject(@store.createRecord('event', {
-        startDate: moment(ev.get('whenGiven.start')).format('lll'),
-        text:ev.get('medication.text')+" started.",
+        event: ev
+        isEnd: false,
         type:"medication"
       }))
       if ev.get('whenGiven.end') >= ev.get('whenGiven.start')
         events.pushObject(@store.createRecord('event', {
-          startDate: moment(ev.get('whenGiven.end')).format('lll'),
-          text:ev.get('medication.text')+" stopped.",
+          event: ev
+          isEnd: true,
           type:"medication"
         }))
-
-    #@get("observations").forEach (ev) =>
-      #events.pushObject(@store.createRecord('event', {
-        #startDate: moment(ev.get('appliesDateTime')).format(lll),
-        #text:ev.get('text')+".",
-        #type:"observation"
-      #}))
     events.sortBy('effectiveDate').reverse()
 )
 

--- a/app/models/patient.coffee
+++ b/app/models/patient.coffee
@@ -88,6 +88,8 @@ Patient = DS.Model.extend(
     else
       Math.round(Math.random() * (92 - 65) + 65)
 
+  activeMedications: Ember.computed.filterBy 'medications', 'active', true
+
   inpatientAdmissions: Ember.computed.filter 'encounters', (item) ->
     is_inpatient = false
     item.get('type.firstObject.coding')?.forEach (c, i) ->

--- a/app/templates/components/patient-stats.hbs
+++ b/app/templates/components/patient-stats.hbs
@@ -22,12 +22,12 @@
   <div class="panel-heading-alt">
     <div class="panel-title">
       <i class="icon-med-clipboard"></i>
-      Conditions ({{patient.conditions.length}})
+      Conditions ({{patient.activeConditions.length}})
     </div>
   </div>
   <div class="panel-body">
     <ul>
-    {{#each condition in patient.conditions}}
+    {{#each condition in patient.activeConditions}}
       {{#if condition.code}}
         <li>{{condition.text}}</li>
       {{/if}}
@@ -48,11 +48,11 @@
   <div class="panel-heading-alt">
     <div class="panel-title">
       <i class="icon-medication"></i>
-      Medications ({{patient.medications.length}})
+      Medications ({{patient.activeMedications.length}})
     </div>
   </div>
   <div class="panel-body">
-    {{#each medication in patient.medications}}
+    {{#each medication in patient.activeMedications}}
       {{#if medication.medication}}
         <li>{{medication.medication.text}}</li>
       {{/if}}

--- a/tests/unit/models/condition-test.coffee
+++ b/tests/unit/models/condition-test.coffee
@@ -1,0 +1,19 @@
+`import { test, moduleForModel } from 'ember-qunit'`
+
+moduleForModel 'condition', 'Conditon', {
+  # Specify the other units that are required for this test.
+  needs: ['model:resource-reference', 'model:identifier', 'model:codeable-concept',
+          'model:location', 'model:period', 'model:coding']
+}
+
+test 'a condition without an abatementDate is active', ->
+  model = @subject()
+  ok model.get('active')
+
+test 'a condition with an abatementDate in the future is active', ->
+  model = @subject({abatementDate: new Date(2020, 1, 1)})
+  ok model.get('active')
+
+test 'a condition with an abatementDate in the past is not active', ->
+  model = @subject({abatementDate: new Date(2000, 1, 1)})
+  ok !model.get('active')

--- a/tests/unit/models/medication-statement-test.coffee
+++ b/tests/unit/models/medication-statement-test.coffee
@@ -1,0 +1,20 @@
+`import { test, moduleForModel } from 'ember-qunit'`
+
+moduleForModel 'medication-statement', 'MedicationStatement', {
+  # Specify the other units that are required for this test.
+  needs: ['model:resource-reference', 'model:identifier', 'model:codeable-concept',
+          'model:dosage', 'model:period', 'model:coding', 'model:medication',
+          'model:quantity']
+}
+
+test 'a medication statement without an period end is active', ->
+  model = @subject()
+  ok model.get('active')
+
+test 'a medication statement with an period end in the future is active', ->
+  model = @subject({period: {end: new Date(2020, 1, 1)}})
+  ok model.get('active')
+
+test 'a medication statement with an period end in the past is not active', ->
+  model = @subject({period: {end: new Date(2000, 1, 1)}})
+  ok !model.get('active')

--- a/tests/unit/models/medication-statement-test.coffee
+++ b/tests/unit/models/medication-statement-test.coffee
@@ -12,9 +12,15 @@ test 'a medication statement without an period end is active', ->
   ok model.get('active')
 
 test 'a medication statement with an period end in the future is active', ->
-  model = @subject({period: {end: new Date(2020, 1, 1)}})
+  period = null
+  Ember.run =>
+    period = @store().createRecord('period', {end: new Date(2020, 1, 1)})
+  model = @subject({whenGiven: period})
   ok model.get('active')
 
 test 'a medication statement with an period end in the past is not active', ->
-  model = @subject({period: {end: new Date(2000, 1, 1)}})
+  period = null
+  Ember.run =>
+    period = @store().createRecord('period', {end: new Date(2000, 1, 1)})
+  model = @subject({whenGiven: period})
   ok !model.get('active')

--- a/tests/unit/models/patient-test.coffee
+++ b/tests/unit/models/patient-test.coffee
@@ -74,6 +74,14 @@ moduleForModel 'patient', 'Patient', {
                     Code: [{Coding: [{System: "http://hl7.org/fhir/sid/icd-9", Code: "305.00"}], Text: "Diagnosis, Active: Alcohol and Drug Dependence"}]
                     DateAsserted: "2012-10-03T08:00:00-04:00"
                   }
+                },
+                {
+                  content: {
+                    id: 2
+                    Code: [{Coding: [{System: "http://hl7.org/fhir/sid/icd-9", Code: "305.00"}], Text: "Diagnosis, Active: Alcohol and Drug Dependence"}]
+                    DateAsserted: "2012-10-03T08:00:00-04:00",
+                    AbatementDate: "2012-11-03T08:00:00-04:00"
+                  }
                 }
               ]
               })
@@ -158,7 +166,7 @@ test 'conditions load', ->
     patient = store.find('patient', 1)
   patient.then ->
     patient.get('conditions').then ->
-      equal patient.get('conditions.length'), 1
+      equal patient.get('conditions.length'), 2
 
 test 'medications load', ->
   store = @store()
@@ -169,6 +177,17 @@ test 'medications load', ->
   patient.then ->
     patient.get('medications').then ->
       equal patient.get('medications.length'), 1
+
+test 'active conditions', ->
+  store = @store()
+  patient = null
+  admissions = null
+  Ember.run ->
+    patient = store.find('patient', 1)
+  patient.then ->
+    patient.get('conditions').then ->
+      equal patient.get('conditions.length'), 2
+      equal patient.get('activeConditions.length'), 1
 
 test 'categoryDisplay data is correct', ->
   store = @store()
@@ -183,7 +202,7 @@ test 'categoryDisplay data is correct', ->
         patient.get('encounters')
       ]).then ->
       wheel = patient.get('categoryDisplay')
-      equal wheel.filterBy('name', 'conditions')?[0].risk, 1
+      equal wheel.filterBy('name', 'conditions')?[0].risk, 2
       equal wheel.filterBy('name', 'medications')?[0].risk, 1
       equal wheel.filterBy('name', 'inpatientAdmissions')?[0].risk, 2
       equal wheel.filterBy('name', 'readmissions')?[0].risk, 1


### PR DESCRIPTION
This filters down the patient page to display only active medications and conditions. A few things to note about the current state of affairs:
- Since most of us are working with the Cypress test deck patients and the data is oriented around 2012, a lot of data is lacking for things like medications
- Currently, there are issues with our go FHIR implementation where all unavailable dates get written out as January 1, 1900. This causes issues if you are loading data with hdsfhir since all abatementDates will be set in the distant past. Everything on the client side works as expected and if you tweak the database serverside, you should see the expected results. We will be fixing the FHIR implementation so that everything works as expected.
