### PR TITLE
Handles case change in the FHIR server

### DIFF
--- a/app/serializers/medication-statement.coffee
+++ b/app/serializers/medication-statement.coffee
@@ -10,8 +10,9 @@ MedicationStatementSerializer = ApplicationSerializer.extend
     dosage : {embedded: 'always'}
 
   normalize: (type, hash, prop) ->
-    medUrl = new URI(hash.content.Medication.Reference)
+    medUrl = new URI(hash.content.medication.Reference)
     if medUrl?
+      hash.content.medication = null
       (hash.content||hash)["links"] = medication: medUrl.path()
     @_super(type, hash, prop)
 


### PR DESCRIPTION
Previously the MedicationStatement serializer was expecting a hash key
of "Medication". The FHIR server has been updated and it properly
produces JSON will all lower case keys. This code updates the
serializer to deal with that.
