### PR TITLE
Fix live reload

### DIFF
--- a/server/proxies/api.js
+++ b/server/proxies/api.js
@@ -1,4 +1,4 @@
-var proxyPath = '/';
+var proxyPath = '/api';
 
 module.exports = function(app) {
   // For options, see:


### PR DESCRIPTION
Because we were proxying ALL requests to the go backend and it doesn't have the CSS/JS files it was failing to load. 
