### PR TITLE
Fix issue with text getting removed from meds, encounters, conditions, and encounters

### DIFF
--- a/app/models/condition.coffee
+++ b/app/models/condition.coffee
@@ -44,7 +44,7 @@ Condition = DS.Model.extend(
   notes: DS.attr('string')
 
   text: (->
-    @get('code.text')?.match(/:\s+([^(]+)\s+\(/)?[1]||""
+    @get('code.text')?.match(/:\s+([^(]+)\s+\(/)?[1]||@get('code.text')
   ).property('code')
 
   startDate: Em.computed('onsetDate', -> @get('onsetDate'))

--- a/app/models/encounter.coffee
+++ b/app/models/encounter.coffee
@@ -47,7 +47,7 @@ Encounter = DS.Model.extend(CodeableMixin, DateableMixin,
   partOf: DS.belongsTo('resource-reference')
 
   text: (->
-    @get('type.firstObject.text')?.match(/:\s+([^(]+)\s+\(/)?[1]||""
+    @get('type.firstObject.text')?.match(/:\s+([^(]+)\s+\(/)?[1]||@get('code.firstObject.text')
   ).property('type')
 
   startDate: Em.computed('period.start', -> @get('period.start'))

--- a/app/models/medication.coffee
+++ b/app/models/medication.coffee
@@ -34,8 +34,8 @@ Medication = DS.Model.extend
   kind: DS.attr('string')
 
   text: (->
-    @get('name')?.match(/:\s+([^(]+)\s+\(/)?[1]||""
+    @get('name')?.match(/:\s+([^(]+)\s+\(/)?[1]||@get('name')
   ).property('name')
-  
+
 
 `export default Medication`


### PR DESCRIPTION
In the case of not matching the regex we want to just return the value to make sure something is there
