### PR TITLE
Indicate event end dates on the timeline (temporary fix)

### DIFF
--- a/app/templates/components/timeline-event.hbs
+++ b/app/templates/components/timeline-event.hbs
@@ -1,6 +1,9 @@
 <div class="timeline-event {{eventClass}}">
   <div class="timeline-event-text">
     {{event.event.text}}
+    {{#if event.isEnd}}
+    (End)
+    {{/if}}
   </div>
 
   <div class="timeline-event-start-date">


### PR DESCRIPTION
The timeline was confusing (and misleading) because it listed event end dates in the timeline, but didn't indicate they were end dates.  As a result, it looked like the event happened twice.

This PR implements the simplest of fixes, simply adding "(End)" to the end of the description if the timeline event indicates the end of something.  I'm sure there is a prettier approach, but I felt it was more important to fix the misperception now and make it pretty later.
