### PR TITLE
Only display confirmed conditions

### DIFF
--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -49,11 +49,13 @@ let IEPatient = Patient.extend({
       }
     });
     this.get('conditions').map(function(e){
-      let patient_event = e.store.createRecord('patient-event', {event: e, type: "condition"});
-      events.push(patient_event);
-      if(e.hasOccured('endDate')){
-        let patient_event = e.store.createRecord('patient-event', {event: e, type: "condition", isEnd: true});
+      if (e.get('verificationStatus') === 'confirmed') {
+        let patient_event = e.store.createRecord('patient-event', {event: e, type: "condition"});
         events.push(patient_event);
+        if(e.hasOccured('endDate')){
+          let patient_event = e.store.createRecord('patient-event', {event: e, type: "condition", isEnd: true});
+          events.push(patient_event);
+        }
       }
     });
     this.get('medications').map(function(e){
@@ -72,7 +74,7 @@ let IEPatient = Patient.extend({
   }),
 
   activeConditions: Ember.computed.filter("conditions", function(cond){
-    return cond.isActive('endDate');
+    return cond.isActive('endDate') && cond.get('verificationStatus') === 'confirmed' ;
   }),
 
   futureAppointments: Ember.computed.filter("appointments", function(appointment){

--- a/tests/unit/models/patient-test.coffee
+++ b/tests/unit/models/patient-test.coffee
@@ -125,6 +125,7 @@ test 'correctly identify active conditions', ->
     codeableConcept.get('coding').pushObject(coding)
     condition.set('code', codeableConcept)
     condition.set("onsetDate", "2012-10-03T08:00:00-04:00")
+    condition.set("verificationStatus", "confirmed")
     patient.get('conditions').pushObject(condition)
 
     condition = store.createRecord('condition', {})
@@ -138,6 +139,7 @@ test 'correctly identify active conditions', ->
     condition.set('code', codeableConcept)
     condition.set("onsetDate", "2012-10-03T08:00:00-04:00")
     condition.set("abatementDateTime", "2013-10-03T08:00:00-04:00")
+    condition.set("verificationStatus", "confirmed")
     patient.get('conditions').pushObject(condition)
 
     equal patient.get('conditions.length'), 2


### PR DESCRIPTION
NOTE: After taking this change, only conditions with `verificationStatus` set to `confirmed` will show up in the UI.  This means you will likely need to re-import and/or regenerate the patients in your database.
