### PR TITLE
Fixing POST content type on InstaCount

### DIFF
--- a/app/components/filter-counts.js
+++ b/app/components/filter-counts.js
@@ -25,12 +25,14 @@ export default Ember.Component.extend({
 
     let group = this.get('group');
 
-    let request = Ember.$.post("/InstaCountAll", JSON.stringify(group ? group.serialize() : {}));
+    let request = Ember.$.ajax({url: "/InstaCountAll",
+                                type: "POST",
+                                data: JSON.stringify(group ? group.serialize() : {}),
+                                contentType: "application/json"});
     request.then((res) => {
-      let response = JSON.parse(res);
-      this.set('patientCount', response.patients);
-      this.set('conditionCount', response.conditions);
-      this.set('encounterCount', response.encounters);
+      this.set('patientCount', res.patients);
+      this.set('conditionCount', res.conditions);
+      this.set('encounterCount', res.encounters);
       this.set('loading', false);
     }, () => {
       this.set('patientCount', 0);

--- a/app/mixins/condition-encounter-code-filters.js
+++ b/app/mixins/condition-encounter-code-filters.js
@@ -47,7 +47,11 @@ export default Ember.Mixin.create({
           limit: AUTOCOMPLETE_ITEM_MAX
         };
 
-        $.post("/CodeLookup", JSON.stringify(queryParams)).then((results) => {
+        let request = $.ajax({url: "/CodeLookup",
+                          type: "POST",
+                          data: JSON.stringify(queryParams),
+                          contentType: "application/json"});
+        request.then((results) => {
           process(results.map((result) => {
             return { name: result.Name, code: result.Code };
           }));


### PR DESCRIPTION
With the switch to Echo on the back end, it is much more particular about the
content type of the request it receives. Previous code put JSON in the request
body but would set the content type to be form encoded, which is wrong.
This change sends the proper application/json content type.

This should work with either the Echo or gorilla/negroni based backend.
