### PR TITLE
Improved Huddle Display and Functionality

### DIFF
--- a/app/components/add-to-huddle-modal.js
+++ b/app/components/add-to-huddle-modal.js
@@ -92,6 +92,10 @@ export default Component.extend(HasStylesheetMixin, {
     }
   },
 
+  rescheduleHuddles() {
+    return this.get('ajax').request('/ScheduleHuddles');
+  },
+
   actions: {
     save(event) {
       event.preventDefault();
@@ -126,7 +130,7 @@ export default Component.extend(HasStylesheetMixin, {
         }
 
         this.get('patientHuddles').pushObject(huddle);
-        this.attrs.onClose();
+        this.rescheduleHuddles().finally(this.attrs.onClose);
       }).catch(() => {
         alert('Failed to save huddle, please try your request again');
         this.set('formSaving', false);

--- a/app/components/huddle-discussed-icon.js
+++ b/app/components/huddle-discussed-icon.js
@@ -1,0 +1,50 @@
+import Component from 'ember-component';
+import computed from 'ember-computed';
+import moment from 'moment';
+
+export default Component.extend({
+  tagName: 'i',
+  classNameBindings: ['iconClass'],
+
+  huddle: null,
+  patient: null,
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    this.$().tooltip({
+      container: 'body',
+      title: () => {
+        let reviewed = this.get('reviewed');
+        if (reviewed != null) {
+          return `Discussed on ${moment(reviewed).format('ll')}`;
+        }
+      }
+    });
+  },
+
+  willDestoryElement() {
+    this._super(...arguments);
+    this.$().tooltip('destroy');
+  },
+
+  huddlePatient: computed('huddle', 'patient', {
+    get() {
+      let huddle = this.get('huddle');
+      if (huddle) {
+        return huddle.getHuddlePatient(this.get('patient'));
+      }
+    }
+  }),
+
+  reviewed: computed.oneWay('huddlePatient.reviewed'),
+
+  iconClass: computed('reviewed', {
+    get() {
+      if (this.get('reviewed') != null) {
+        return 'fa fa-fw fa-check-square-o';
+      }
+      return 'hidden';
+    }
+  })
+});

--- a/app/components/huddle-reason-icon.js
+++ b/app/components/huddle-reason-icon.js
@@ -1,0 +1,57 @@
+import Component from 'ember-component';
+import computed from 'ember-computed';
+import { REASON_CODES } from 'ember-on-fhir/models/huddle-patient';
+
+export default Component.extend({
+  tagName: 'i',
+  classNameBindings: ['reasonIconClass'],
+
+  huddle: null,
+  patient: null,
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    this.$().tooltip({
+      container: 'body',
+      title: () => {
+        return this.get('huddlePatient.reasonText');
+      }
+    });
+  },
+
+  willDestoryElement() {
+    this._super(...arguments);
+    this.$().tooltip('destroy');
+  },
+
+  huddlePatient: computed('huddle', 'patient', {
+    get() {
+      let huddle = this.get('huddle');
+      if (huddle) {
+        return huddle.getHuddlePatient(this.get('patient'));
+      }
+    }
+  }),
+
+  reasonIconClass: computed('huddlePatient.reason', {
+    get() {
+      let reason = this.get('huddlePatient.reason');
+      if (reason === REASON_CODES.CARRYOVER) {
+        return 'fa fa-fw fa-arrow-circle-o-right';
+      } else if (reason === REASON_CODES.MANUAL_ADDITION) {
+        return 'fa fa-fw fa-pencil';
+      } else if (reason === REASON_CODES.RECENT_ADMISSION) {
+        return 'fa fa-fw fa-h-square';
+      } else if (reason === REASON_CODES.RECENT_ED_VISIT) {
+        return 'fa fa-fw fa-ambulance';
+      } else if (reason === REASON_CODES.RECENT_READMISSION) {
+        return 'fa fa-fw fa-hospital-o';
+      } else if (reason === REASON_CODES.RISK_SCORE) {
+        return 'fa fa-fw fa-pie-chart';
+      }
+
+      return 'hidden';
+    }
+  })
+});

--- a/app/components/huddle-reason-icon.js
+++ b/app/components/huddle-reason-icon.js
@@ -36,7 +36,7 @@ export default Component.extend({
 
   reasonIconClass: computed('huddlePatient.reason', {
     get() {
-      switch(this.get('huddlePatient.reason')) {
+      switch (this.get('huddlePatient.reason')) {
         case REASON_CODES.CARRYOVER:
           return 'fa fa-fw fa-arrow-circle-o-right';
         case REASON_CODES.MANUAL_ADDITION:

--- a/app/components/huddle-reason-icon.js
+++ b/app/components/huddle-reason-icon.js
@@ -36,22 +36,22 @@ export default Component.extend({
 
   reasonIconClass: computed('huddlePatient.reason', {
     get() {
-      let reason = this.get('huddlePatient.reason');
-      if (reason === REASON_CODES.CARRYOVER) {
-        return 'fa fa-fw fa-arrow-circle-o-right';
-      } else if (reason === REASON_CODES.MANUAL_ADDITION) {
-        return 'fa fa-fw fa-pencil';
-      } else if (reason === REASON_CODES.RECENT_ADMISSION) {
-        return 'fa fa-fw fa-h-square';
-      } else if (reason === REASON_CODES.RECENT_ED_VISIT) {
-        return 'fa fa-fw fa-ambulance';
-      } else if (reason === REASON_CODES.RECENT_READMISSION) {
-        return 'fa fa-fw fa-hospital-o';
-      } else if (reason === REASON_CODES.RISK_SCORE) {
-        return 'fa fa-fw fa-pie-chart';
+      switch(this.get('huddlePatient.reason')) {
+        case REASON_CODES.CARRYOVER:
+          return 'fa fa-fw fa-arrow-circle-o-right';
+        case REASON_CODES.MANUAL_ADDITION:
+          return 'fa fa-fw fa-pencil';
+        case REASON_CODES.RECENT_ADMISSION:
+          return 'fa fa-fw fa-h-square';
+        case REASON_CODES.RECENT_ED_VISIT:
+          return 'fa fa-fw fa-ambulance';
+        case REASON_CODES.RECENT_READMISSION:
+          return 'fa fa-fw fa-hospital-o';
+        case REASON_CODES.RISK_SCORE:
+          return 'fa fa-fw fa-pie-chart';
+        default:
+          return 'hidden';
       }
-
-      return 'hidden';
     }
   })
 });

--- a/app/components/patient-badge.js
+++ b/app/components/patient-badge.js
@@ -15,8 +15,7 @@ export default Component.extend(PatientIconClassNames, {
 
   nextHuddle: computed('huddles.@each.date', {
     get() {
-      let patient = this.get('patient');
-      let huddles = this.get('huddles').filter((huddle) => !huddle.patientReviewed(patient) && isTodayOrAfter([huddle.get('date')]));
+      let huddles = this.get('huddles').filter((huddle) => isTodayOrAfter([huddle.get('date')]));
       return huddles.sortBy('date').objectAt(0);
     }
   }),

--- a/app/components/patient-viewer.js
+++ b/app/components/patient-viewer.js
@@ -19,7 +19,6 @@ export default Component.extend(HasStylesheetMixin, {
       return new Date();
     }
   }),
-  schedulePanelOpen: false,
 
   huddles: computed({
     get() {
@@ -87,8 +86,7 @@ export default Component.extend(HasStylesheetMixin, {
 
   futureHuddles: computed('huddles.@each.date', 'nextScheduledHuddle', {
     get() {
-      let patient = this.get('patient');
-      return this.get('huddles').filter((huddle) => !huddle.patientReviewed(patient) && isTodayOrAfter([huddle.get('date')])).sort((a, b) => a.get('date') - b.get('date'));
+      return this.get('huddles').filter((huddle) => isTodayOrAfter([huddle.get('date')])).sort((a, b) => a.get('date') - b.get('date'));
     }
   }),
 
@@ -156,11 +154,5 @@ export default Component.extend(HasStylesheetMixin, {
     }
 
     return 0;
-  }),
-
-  actions: {
-    toggleScheduleChevron() {
-      this.toggleProperty('schedulePanelOpen');
-    }
-  }
+  })
 });

--- a/app/controllers/patients/show.js
+++ b/app/controllers/patients/show.js
@@ -1,7 +1,11 @@
 import Controller from 'ember-controller';
 import computed from 'ember-computed';
+import service from 'ember-service/inject';
+import { parseHuddles } from 'ember-on-fhir/models/huddle';
 
 export default Controller.extend({
+  ajax: service(),
+
   currentAssessment: 'Stroke',
   selectedCategory: null,
   showAddInterventionModal: false,
@@ -49,6 +53,15 @@ export default Controller.extend({
 
     hideAddHuddleModal() {
       this.set('showAddHuddleModal', false);
+
+      this.get('ajax').request('/Group', {
+        data: {
+          code: 'http://interventionengine.org/fhir/cs/huddle|HUDDLE',
+          member: `Patient/${this.get('model.id')}`
+        }
+      }).then((response) => {
+        this.set('huddles', parseHuddles(response.entry || []));
+      });
     },
 
     openReviewPatientModal(huddle) {

--- a/app/models/huddle-patient.js
+++ b/app/models/huddle-patient.js
@@ -1,6 +1,15 @@
 import EmberObject from 'ember-object';
 import moment from 'moment';
 
+export const REASON_CODES = {
+  CARRYOVER: 'CARRYOVER',
+  MANUAL_ADDITION: 'MANUAL_ADDITION',
+  RECENT_ADMISSION: 'RECENT_ADMISSION',
+  RECENT_ED_VISIT: 'RECENT_ED_VISIT',
+  RECENT_READMISSION: 'RECENT_READMISSION',
+  RISK_SCORE: 'RISK_SCORE'
+};
+
 export default EmberObject.extend({
   patientId: null,
   reason: null,

--- a/app/models/huddle.js
+++ b/app/models/huddle.js
@@ -36,6 +36,12 @@ const Huddle = EmberObject.extend({
     this.get('patients').pushObject(huddlePatient);
   },
 
+  getHuddlePatient(patient) {
+    if (patient != null) {
+      return this.get('patients').findBy('patientId', get(patient, 'id'));
+    }
+  },
+
   hasPatient(patient) {
     if (patient == null) {
       return false;
@@ -44,11 +50,9 @@ const Huddle = EmberObject.extend({
   },
 
   patientReviewed(patient) {
-    if (patient != null) {
-      let huddlePatient = this.get('patients').findBy('patientId', get(patient, 'id'));
-      if (huddlePatient != null) {
-        return huddlePatient.get('reviewed') != null;
-      }
+    let huddlePatient = this.getHuddlePatient(patient);
+    if (huddlePatient != null) {
+      return huddlePatient.get('reviewed') != null;
     }
 
     return false;

--- a/app/templates/components/patient-badge.hbs
+++ b/app/templates/components/patient-badge.hbs
@@ -32,10 +32,9 @@
         <div class="col-xs-6">
           {{#if nextHuddle}}
             <span class="patient-next-huddle">
-              <i class="fa fa-users"></i>
+              {{huddle-reason-icon patient=patient huddle=nextHuddle}}
               {{moment-format nextHuddle.date 'll'}}
               {{huddle-discussed-icon patient=patient huddle=nextHuddle}}
-              {{huddle-reason-icon patient=patient huddle=nextHuddle}}
             </span>
           {{/if}}
         </div>

--- a/app/templates/components/patient-badge.hbs
+++ b/app/templates/components/patient-badge.hbs
@@ -34,6 +34,8 @@
             <span class="patient-next-huddle">
               <i class="fa fa-users"></i>
               {{moment-format nextHuddle.date 'll'}}
+              {{huddle-discussed-icon patient=patient huddle=nextHuddle}}
+              {{huddle-reason-icon patient=patient huddle=nextHuddle}}
             </span>
           {{/if}}
         </div>

--- a/app/templates/components/patient-summary.hbs
+++ b/app/templates/components/patient-summary.hbs
@@ -31,6 +31,8 @@
           <span class="patient-next-huddle">
             <i class="fa fa-users"></i>
             {{moment-format huddle.date 'll'}}
+            {{huddle-discussed-icon patient=patient huddle=huddle}}
+            {{huddle-reason-icon patient=patient huddle=huddle}}
           </span>
         {{/if}}
       </div>

--- a/app/templates/components/patient-summary.hbs
+++ b/app/templates/components/patient-summary.hbs
@@ -15,24 +15,27 @@
             <span class="badge">{{patient.notifications.count}}</span>
           {{/if}}
         </div>
+
         <span class="patient-age">
           <i class={{ageIconClassName}}></i>
           {{patient.computedAge}} yrs
         </span>
+
         <span class="patient-gender">
           <i class="fa {{genderIconClassName}}"></i>
           {{patient.computedGender}}
         </span>
+
         <span class="patient-location">
           <i class="fa fa-map-marker"></i>
           {{patient.location}}
         </span>
+
         {{#if huddle}}
           <span class="patient-next-huddle">
-            <i class="fa fa-users"></i>
+            {{huddle-reason-icon patient=patient huddle=huddle}}
             {{moment-format huddle.date 'll'}}
             {{huddle-discussed-icon patient=patient huddle=huddle}}
-            {{huddle-reason-icon patient=patient huddle=huddle}}
           </span>
         {{/if}}
       </div>

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -39,7 +39,7 @@
         <div class="collapse-panel-title">
           <a data-toggle="collapse" href="#huddleList" aria-expanded="true" aria-controls="collapseOne">
             <i class="fa fa-users fa-fw"></i>
-            Huddle
+            Huddles
             <i class="fa fa-chevron-down pull-right"></i>
           </a>
         </div>

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -47,22 +47,8 @@
       <div class="panel-body">
         <div class="collapse in" id="huddleList">
           <form class="form-horizontal form-group-striped">
-            {{#if futureDisplayHuddle}}
-              <div class="form-group">
-                <div class="next-huddle-date">
-                  <i class="fa fa-calendar-o"></i>
-                  {{moment-format futureDisplayHuddle.date 'MMM D, YYYY'}}
-
-                  <i class="fa fa-check-square-o pull-right cursor-pointer" onclick={{action attrs.openReviewPatientModal futureDisplayHuddle}}></i>
-                </div>
-              </div>
-            {{/if}}
             <div class="add-new-filter-lg">
-              <button type="button" class="btn btn-link" data-toggle="collapse" data-target="#patientViewerPikaday" aria-expanded="false" aria-controls="patientViewerPikaday" onclick={{action 'toggleScheduleChevron'}}>
-                <i class="fa fa-calendar-o"></i> Schedule <i class="fa {{if schedulePanelOpen 'fa-chevron-down' 'fa-chevron-right'}}"></i>
-              </button>
-
-              <div id="patientViewerPikaday" class="collapse">
+              <div id="patientViewerPikaday">
                 <div id="patientViewerPikadayCalendar"></div>
                 <div class="patient-viewer-schedule-block">
                   {{moment-format selectedScheduleDate 'MMM D, YYYY'}}
@@ -83,7 +69,7 @@
                       {{selectedScheduleHuddlePatient.reasonText}}
                       {{#if selectedScheduleHuddlePatient.reviewed}}
                         <br>
-                        Reviewed on {{moment-format selectedScheduleHuddlePatient.reviewed 'MMM D, YYYY'}}
+                        Discussed on {{moment-format selectedScheduleHuddlePatient.reviewed 'MMM D, YYYY'}}
                       {{/if}}
                     {{else}}
                       Not scheduled

--- a/app/templates/components/review-patient-modal.hbs
+++ b/app/templates/components/review-patient-modal.hbs
@@ -1,4 +1,4 @@
-{{#bootstrap-modal title="Review Patient" onOpen=attrs.onOpen onClose=attrs.onClose}}
+{{#bootstrap-modal title="Mark Patient as Discussed" onOpen=attrs.onOpen onClose=attrs.onClose}}
   <form onsubmit={{action 'save'}}>
     <div class="modal-body review-patient-modal-body">
       <div class="form-group">
@@ -52,7 +52,7 @@
       <div class="form-group">
         <div class="row">
           <div class="col-sm-6">
-            <label for="reviewDate">Patient Reviewed on:</label>
+            <label for="reviewDate">Patient Discussed on:</label>
           </div>
 
           <div class="col-sm-6 form-value">


### PR DESCRIPTION
# Improved Huddle Display and Functionality
-   Changed huddle date display to always show the next huddle date regardless of if discussed.
-   Added icons with tooltips for each huddle date to indicate the reason the patient was added to that huddle.
-      Added tooltip to indicate when patient was discussed.
-   Refactored the patient viewer huddle list to always display the calendar.
-   Added call to the `ScheduleHuddles` endpoint when manually adding a patient to a huddle to automatically recalculate all future huddles.
#### Screenshots

![screen shot 2016-04-08 at 9 45 44 am](https://cloud.githubusercontent.com/assets/5418735/14385738/008a6f92-fd70-11e5-816a-45decb74888b.png)

![screen shot 2016-04-08 at 9 58 39 am](https://cloud.githubusercontent.com/assets/5418735/14385880/887d414a-fd70-11e5-90c9-74e86bffaa82.png)

![screen shot 2016-04-08 at 9 45 55 am](https://cloud.githubusercontent.com/assets/5418735/14385743/025b35ae-fd70-11e5-88a4-c07345cf6e28.png)
