### PR TITLE
Added Edit Functionality for Manually Added Huddles and Unmarking Patients as Discussed

### DIFF
--- a/app/components/add-to-huddle-modal.js
+++ b/app/components/add-to-huddle-modal.js
@@ -20,7 +20,15 @@ export default Component.extend(HasStylesheetMixin, {
       return this.get('defaultDate') || new Date();
     }
   }),
-  huddleLeader: '',
+  huddleLeader: computed('huddle.displayLeader', {
+    get() {
+      let huddle = this.get('huddle');
+      if (huddle != null) {
+        return huddle.get('displayLeader');
+      }
+      return '';
+    }
+  }),
   patient: null,
   isLoading: true,
   huddleLeaderDisabled: computed.notEmpty('existingHuddle'),

--- a/app/components/patient-viewer.js
+++ b/app/components/patient-viewer.js
@@ -13,6 +13,7 @@ export default Component.extend(HasStylesheetMixin, {
   currentAssessment: null,
   selectedCategory: null,
   nextScheduledHuddle: null,
+  displayClearDiscussedModal: false,
 
   selectedScheduleDate: computed({
     get() {
@@ -154,5 +155,12 @@ export default Component.extend(HasStylesheetMixin, {
     }
 
     return 0;
-  })
+  }),
+
+  actions: {
+    closeReviewPatientModal() {
+      this.set('displayClearDiscussedModal', false);
+      this.notifyPropertyChange('nextScheduledHuddle');
+    }
+  }
 });

--- a/app/components/patient-viewer.js
+++ b/app/components/patient-viewer.js
@@ -13,6 +13,7 @@ export default Component.extend(HasStylesheetMixin, {
   currentAssessment: null,
   selectedCategory: null,
   nextScheduledHuddle: null,
+  displayEditHuddleModal: false,
   displayClearDiscussedModal: false,
 
   selectedScheduleDate: computed({
@@ -161,6 +162,11 @@ export default Component.extend(HasStylesheetMixin, {
     closeReviewPatientModal() {
       this.set('displayClearDiscussedModal', false);
       this.notifyPropertyChange('nextScheduledHuddle');
+    },
+
+    closeEditHuddleModal() {
+      this.set('displayEditHuddleModal', false);
+      this.attrs.refreshHuddles();
     }
   }
 });

--- a/app/components/remove-discussed-patient-modal.js
+++ b/app/components/remove-discussed-patient-modal.js
@@ -1,0 +1,38 @@
+import Component from 'ember-component';
+import service from 'ember-service/inject';
+import computed from 'ember-computed';
+
+export default Component.extend({
+  ajax: service(),
+
+  huddle: null,
+  patient: null,
+
+  huddlePatient: computed('huddle', 'patient', {
+    get() {
+      return this.get('huddle.patients').findBy('patientId', this.get('patient.id'));
+    }
+  }),
+
+  actions: {
+    save(event) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
+      this.get('huddlePatient').set('reviewed', null);
+
+      let huddle = this.get('huddle');
+      let promise = this.get('ajax').request(`/Group/${huddle.get('id')}`, {
+        data: JSON.stringify(huddle.toFhirJson()),
+        type: 'PUT',
+        contentType: 'application/json; charset=UTF-8'
+      });
+
+      promise.then(() => this.attrs.onClose());
+      promise.catch(() => {
+        this.get('huddlePatient').set('reviewed', null);
+        alert('Failed to save to the server, please try your request again');
+      });
+    }
+  }
+});

--- a/app/controllers/patients/show.js
+++ b/app/controllers/patients/show.js
@@ -28,6 +28,17 @@ export default Controller.extend({
     }
   }),
 
+  refreshHuddles() {
+    this.get('ajax').request('/Group', {
+      data: {
+        code: 'http://interventionengine.org/fhir/cs/huddle|HUDDLE',
+        member: `Patient/${this.get('model.id')}`
+      }
+    }).then((response) => {
+      this.set('huddles', parseHuddles(response.entry || []));
+    });
+  },
+
   actions: {
     setRiskAssessment(riskAssessment) {
       this.set('currentAssessment', riskAssessment);
@@ -53,15 +64,11 @@ export default Controller.extend({
 
     hideAddHuddleModal() {
       this.set('showAddHuddleModal', false);
+      this.refreshHuddles();
+    },
 
-      this.get('ajax').request('/Group', {
-        data: {
-          code: 'http://interventionengine.org/fhir/cs/huddle|HUDDLE',
-          member: `Patient/${this.get('model.id')}`
-        }
-      }).then((response) => {
-        this.set('huddles', parseHuddles(response.entry || []));
-      });
+    refreshHuddles() {
+      this.refreshHuddles();
     },
 
     openReviewPatientModal(huddle) {

--- a/app/models/huddle.js
+++ b/app/models/huddle.js
@@ -36,6 +36,14 @@ const Huddle = EmberObject.extend({
     this.get('patients').pushObject(huddlePatient);
   },
 
+  removePatient(patient) {
+    let huddlePatient = this.getHuddlePatient(patient);
+    if (huddlePatient != null) {
+      this.get('patients').removeObject(huddlePatient);
+      return huddlePatient;
+    }
+  },
+
   getHuddlePatient(patient) {
     if (patient != null) {
       return this.get('patients').findBy('patientId', get(patient, 'id'));

--- a/app/styles/_application.scss
+++ b/app/styles/_application.scss
@@ -58,13 +58,23 @@ ul {
   }
 }
 
-.btn-primary {
-  width: 200px;
-  height: 45px;
-  background-color: $brand-primary;
-  border-color: darker($brand-primary, 10%);
+.btn-primary,
+.btn-ie,
+.btn-ie-lg {
   border-radius: 0;
   font-size: 20px;
+  height: 45px;
+}
+
+.btn-primary,
+.btn-ie-lg {
+  width: 200px;
+  height: 45px;
+}
+
+.btn-primary {
+  background-color: $brand-primary;
+  border-color: darker($brand-primary, 10%);
 }
 
 /* -------------------------------- OTHER -------------------------------- */

--- a/app/styles/_patient-viewer.scss
+++ b/app/styles/_patient-viewer.scss
@@ -10,11 +10,18 @@
   margin-top: 0.5em;
   font-weight: 400;
   text-align: center;
+  position: relative;
+
+  .action-icons {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
 
   .fa {
     color: $brand-primary;
     cursor: pointer;
-    margin-top: 6px;
+    // margin-top: 6px;
   }
 
   .meta {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -6,7 +6,7 @@ $brand-alert: #E2495C;      // custom - red
 $body-bg: #EEEEEE;          // light gray
 $body-bg-inverse: #FFFFFF;  // white
 $headings-color: $brand-secondary;
-$btn-default-bg: $brand-primary;
+// $btn-default-bg: $brand-primary;
 // $navbar-inverse-bg: $brand-secondary;
 $navbar-inverse-bg: #454545;
 $navbar-inverse-color: $body-bg-inverse;

--- a/app/templates/components/add-to-huddle-modal.hbs
+++ b/app/templates/components/add-to-huddle-modal.hbs
@@ -1,10 +1,10 @@
-{{#bootstrap-modal title="Add to Huddle" onOpen=attrs.onOpen onClose=attrs.onClose}}
+{{#bootstrap-modal title=title onOpen=attrs.onOpen onClose=attrs.onClose}}
   {{#if isLoading}}
     <div class="modal-body modal-body-spinner">
       {{ember-spinner config='small'}}
     </div>
   {{else}}
-    {{#if patientInExistingHuddle}}
+    {{#if (and patientInExistingHuddle (not-eq huddle.id existingHuddle.id))}}
       <div class="huddle-exists-alert alert alert-danger">
         <i class="fa fa-exclamation-circle"></i>
         Patient already exists in selected huddle.
@@ -14,6 +14,16 @@
     <form onsubmit={{action 'save'}}>
       <div class="modal-body add-to-huddle-modal-body">
         <div id="addToHuddlePikaday" class="form-group">
+          {{#if huddle}}
+            <div class="row form-control-static">
+              <div class="col-sm-4">
+                <label>Current Date:</label>
+              </div>
+              <div class="col-sm-8">
+                {{moment-format huddle.date 'dddd, MMMM Do YYYY'}}
+              </div>
+            </div>
+          {{/if}}
           <div class="row">
             <div class="col-sm-4">
               <label for="huddleDate">Huddle Date:</label>
@@ -55,6 +65,9 @@
       </div>
 
       <div class="modal-footer">
+        {{#if huddle}}
+          <button type="button" class="btn btn-danger btn-ie-lg" disabled={{removeBtnDisabled}} onclick={{action 'removePatientFromHuddle'}}>Remove</button>
+        {{/if}}
         <button type="submit" class="btn btn-primary" disabled={{saveBtnDisabled}}>Save</button>
       </div>
     </form>

--- a/app/templates/components/add-to-huddle-modal.hbs
+++ b/app/templates/components/add-to-huddle-modal.hbs
@@ -55,7 +55,7 @@
                 type="text"
                 id="huddleLeader"
                 class="form-control"
-                value={{if existingHuddle existingHuddle.leader huddleLeader}}
+                value={{if existingHuddle existingHuddle.displayLeader huddleLeader}}
                 onchange={{action (mut huddleLeader) value="target.value"}}
                 onkeyup={{action (mut huddleLeader) value="target.value"}}
                 disabled={{huddleLeaderDisabled}}>

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -51,17 +51,19 @@
               <div id="patientViewerPikaday">
                 <div id="patientViewerPikadayCalendar"></div>
                 <div class="patient-viewer-schedule-block">
-                  {{moment-format selectedScheduleDate 'MMM D, YYYY'}}
-
-                  {{#if selectedScheduleHuddle}}
-                    {{!-- <i class="fa fa-edit pull-right"></i> --}}
-                    {{#unless selectedScheduleHuddlePatient.reviewed}}
-                      <i class="fa fa-check-square-o" onclick={{action attrs.openReviewPatientModal selectedScheduleHuddle}}></i>
-                    {{/unless}}
-                  {{else}}
-                    <i class="fa fa-plus-circle" onclick={{action attrs.openAddHuddleModal selectedScheduleDate}}></i>
-                  {{/if}}
-
+                  <div class="action-icons">
+                    {{#if selectedScheduleHuddle}}
+                      {{#if (eq selectedScheduleHuddlePatient.reason 'MANUAL_ADDITION')}}
+                        <i class="fa fa-edit" onclick={{action (mut displayEditHuddleModal) true}}></i>
+                      {{/if}}
+                      {{#unless selectedScheduleHuddlePatient.reviewed}}
+                        <i class="fa fa-check-square-o" onclick={{action attrs.openReviewPatientModal selectedScheduleHuddle}}></i>
+                      {{/unless}}
+                    {{else}}
+                      <i class="fa fa-plus-circle" onclick={{action attrs.openAddHuddleModal selectedScheduleDate}}></i>
+                    {{/if}}
+                  </div>
+                  <div>{{moment-format selectedScheduleDate 'MMM D, YYYY'}}</div>
                   <div class="meta">
                     {{#if selectedScheduleHuddle}}
                       Geriatrics Huddle<br>
@@ -69,7 +71,8 @@
                       {{selectedScheduleHuddlePatient.reasonText}}
                       {{#if selectedScheduleHuddlePatient.reviewed}}
                         <br>
-                        Discussed on {{moment-format selectedScheduleHuddlePatient.reviewed 'MMM D, YYYY'}} <i class="fa fa-times" onclick={{action (mut displayClearDiscussedModal) true}}></i>
+                        Discussed on {{moment-format selectedScheduleHuddlePatient.reviewed 'MMM D, YYYY'}}
+                        <i class="fa fa-times" onclick={{action (mut displayClearDiscussedModal) true}}></i>
                       {{/if}}
                     {{else}}
                       Not scheduled
@@ -139,6 +142,10 @@
     </div>
   </div>
 </div>
+
+{{#if displayEditHuddleModal}}
+  {{add-to-huddle-modal patient=patient huddle=selectedScheduleHuddle defaultDate=selectedScheduleHuddle.date patientHuddles=huddles onClose=(action 'closeEditHuddleModal')}}
+{{/if}}
 
 {{#if displayClearDiscussedModal}}
   {{remove-discussed-patient-modal patient=patient huddle=selectedScheduleHuddle onClose=(action 'closeReviewPatientModal')}}

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -69,7 +69,7 @@
                       {{selectedScheduleHuddlePatient.reasonText}}
                       {{#if selectedScheduleHuddlePatient.reviewed}}
                         <br>
-                        Discussed on {{moment-format selectedScheduleHuddlePatient.reviewed 'MMM D, YYYY'}}
+                        Discussed on {{moment-format selectedScheduleHuddlePatient.reviewed 'MMM D, YYYY'}} <i class="fa fa-times" onclick={{action (mut displayClearDiscussedModal) true}}></i>
                       {{/if}}
                     {{else}}
                       Not scheduled
@@ -139,3 +139,7 @@
     </div>
   </div>
 </div>
+
+{{#if displayClearDiscussedModal}}
+  {{remove-discussed-patient-modal patient=patient huddle=selectedScheduleHuddle onClose=(action 'closeReviewPatientModal')}}
+{{/if}}

--- a/app/templates/components/remove-discussed-patient-modal.hbs
+++ b/app/templates/components/remove-discussed-patient-modal.hbs
@@ -1,0 +1,43 @@
+{{#bootstrap-modal title='Remove Patient as Discussed' onClose=(action attrs.onClose)}}
+  <form onsubmit={{action 'save'}}>
+    <div class="modal-body review-patient-modal-body">
+      <div class="form-group">
+        <div class="form-control-static row">
+          <div class="col-sm-6">
+            <label>Patient:</label>
+          </div>
+
+          <div class="col-sm-6 form-value">
+            {{patient.fullName}}
+          </div>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="form-control-static row">
+          <div class="col-sm-6">
+            <label>Huddle:</label>
+          </div>
+
+          <div class="col-sm-6 form-value">
+            Geriatrics Huddle
+          </div>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="form-control-static row">
+          <div class="col-sm-6">
+            <label>Huddle Date:</label>
+          </div>
+
+          <div class="col-sm-6 form-value">
+            {{moment-format huddle.date 'MMM DD, YYYY'}}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-default" onclick={{action attrs.onClose}}>Cancel</button>
+      <button type="submit" class="btn btn-danger">Remove</button>
+    </div>
+  </form>
+{{/bootstrap-modal}}

--- a/app/templates/components/remove-discussed-patient-modal.hbs
+++ b/app/templates/components/remove-discussed-patient-modal.hbs
@@ -36,8 +36,8 @@
       </div>
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-default" onclick={{action attrs.onClose}}>Cancel</button>
-      <button type="submit" class="btn btn-danger">Remove</button>
+      <button type="button" class="btn btn-default btn-ie-lg" onclick={{action attrs.onClose}}>Cancel</button>
+      <button type="submit" class="btn btn-danger btn-ie-lg">Remove</button>
     </div>
   </form>
 {{/bootstrap-modal}}

--- a/app/templates/patients/show.hbs
+++ b/app/templates/patients/show.hbs
@@ -20,7 +20,8 @@
           openAddHuddleModal=(action 'openAddHuddleModal')
           openReviewPatientModal=(action 'openReviewPatientModal')
           registerPatientViewer=(action 'registerPatientViewer')
-          unregisterPatientViewer=(action 'unregisterPatientViewer')}}
+          unregisterPatientViewer=(action 'unregisterPatientViewer')
+          refreshHuddles=(action 'refreshHuddles')}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Added Edit Functionality for Manually Added Huddles and Unmarking Patients as Discussed
-   Added edit icon next to selected huddle date with allows user to either edit huddle, or remove the patient from it. Behavior:
  -  The 'Save' button is disabled until changes are made.
  -  When a new huddle date is selected:
    -  If huddle already exists, practitioner name is auto-populated and un-editable.
    -  If huddle does not exist, creates new huddle with current practitioner name auto-populated and editable.
    -  When the 'Remove' button is selected, patient is removed from the huddle. If patient was the only patient in that huddle, destroys the huddle as well.
-   Added 'x' icon next to 'Discussed by ...' text on a selected huddle that allows a patient to be unmarked as discussed.
##### TODO:
- [ ] All scheduling logic creating/editing huddles should eventually be moved to the server-side to handle cases where simultaneous scheduling conflicts arise.
##### Screenshots:
###### Edit Manually Added Patient Icon

![screen shot 2016-04-14 at 9 08 31 am](https://cloud.githubusercontent.com/assets/5418735/14529489/c9ed2ce2-0222-11e6-8cc1-f5628295934a.png)
###### Edit Manually Added Patient Dialog

![screen shot 2016-04-14 at 9 08 49 am](https://cloud.githubusercontent.com/assets/5418735/14529518/f29c422c-0222-11e6-8920-c697094d8425.png)
###### Unmark Patient as Discussed Icon

![screen shot 2016-04-14 at 9 05 32 am](https://cloud.githubusercontent.com/assets/5418735/14529543/1341887a-0223-11e6-8f3a-7c27894892ec.png)
###### Unmark Patient as Discussed Dialog

![screen shot 2016-04-14 at 9 04 44 am](https://cloud.githubusercontent.com/assets/5418735/14529554/1ab3d9d2-0223-11e6-9e6a-09ceb2c9112c.png)
