### PR TITLE
Removed UI Features Not Supported in Pilot

### DIFF
--- a/app/components/condition-code-filter.js
+++ b/app/components/condition-code-filter.js
@@ -3,5 +3,10 @@ import FilterComponentMixin from '../mixins/filter-component';
 import ConditionEncounterCodeFiltersMixin from '../mixins/condition-encounter-code-filters';
 
 export default Ember.Component.extend(FilterComponentMixin, ConditionEncounterCodeFiltersMixin, {
-  checkboxBaseName: 'condition-filter'
+  checkboxBaseName: 'condition-filter',
+
+  codingSystems: [
+    { url: 'http://hl7.org/fhir/sid/icd-9', system: 'ICD-9' },
+    { url: 'http://hl7.org/fhir/sid/icd-10', system: 'ICD-10' }
+  ]
 });

--- a/app/components/encounter-code-filter.js
+++ b/app/components/encounter-code-filter.js
@@ -3,5 +3,10 @@ import FilterComponentMixin from '../mixins/filter-component';
 import ConditionEncounterCodeFiltersMixin from '../mixins/condition-encounter-code-filters';
 
 export default Ember.Component.extend(FilterComponentMixin, ConditionEncounterCodeFiltersMixin, {
-  checkboxBaseName: 'encounter-filter'
+  checkboxBaseName: 'encounter-filter',
+
+  codingSystems: [
+    { url: 'http://www.ama-assn.org/go/cpt', system: 'CPT' },
+    { url: 'http://snomed.info/sct', system: 'SNOMED CT' }
+  ]
 });

--- a/app/components/patient-search/sort-by.js
+++ b/app/components/patient-search/sort-by.js
@@ -10,10 +10,10 @@ export default Component.extend({
       return [
         { name: 'Name', sortKey: 'family', sortIcon: 'alpha' },
         { name: 'Age', sortKey: 'birthdate', sortIcon: 'numeric', invert: true },
-        { name: 'Gender', sortKey: 'gender', sortIcon: 'alpha' },
-        { name: 'Location', sortKey: 'address', sortIcon: 'alpha' },
-        { name: 'Risk Score', sortKey: 'riskScore', sortIcon: 'numeric', defaultSortDescending: true },
-        { name: 'Notifications', sortKey: 'notifications', sortIcon: 'numeric', defaultSortDescending: true }
+        { name: 'Gender', sortKey: 'gender', sortIcon: 'alpha' }
+        // { name: 'Location', sortKey: 'address', sortIcon: 'alpha' },
+        // { name: 'Risk Score', sortKey: 'riskScore', sortIcon: 'numeric', defaultSortDescending: true },
+        // { name: 'Notifications', sortKey: 'notifications', sortIcon: 'numeric', defaultSortDescending: true }
       ];
     }
   })

--- a/app/controllers/patients/index.js
+++ b/app/controllers/patients/index.js
@@ -8,7 +8,7 @@ export default Controller.extend({
   page: 1,
   perPage: 8,
 
-  currentAssessment: 'Stroke', // default
+  currentAssessment: 'Catastrophic Health Event', // default
   selectedPopulation: computed('groupId', {
     get() {
       let groupId = this.get('groupId');
@@ -70,7 +70,7 @@ export default Controller.extend({
   riskAssessments: computed({
     get() {
       // TODO: get this list from the backend
-      return ['Stroke', 'Negative Outcome'];
+      return ['Catastrophic Health Event'];
     }
   }),
 

--- a/app/controllers/patients/show.js
+++ b/app/controllers/patients/show.js
@@ -9,8 +9,8 @@ import { parseHuddles } from 'ember-on-fhir/models/huddle';
 export default Controller.extend({
   indexController: controller('patients.index'),
   ajax: service(),
-  queryParams: ['group'],
-  currentAssessment: 'Stroke',
+
+  currentAssessment: 'Catastrophic Health Event',
   selectedCategory: null,
   showAddInterventionModal: false,
   showAddHuddleModal: false,
@@ -51,7 +51,7 @@ export default Controller.extend({
   riskAssessments: computed({
     get() {
       // TODO: get this list from the backend
-      return ['Stroke', 'Negative Outcome'];
+      return ['Catastrophic Health Event'];
     }
   }),
 

--- a/app/mixins/condition-encounter-code-filters.js
+++ b/app/mixins/condition-encounter-code-filters.js
@@ -7,17 +7,18 @@ const AUTOCOMPLETE_ITEM_MAX = 10;
 export default Ember.Mixin.create({
   ajax: service(),
 
-  codingSystems: [
-    { url: 'http://hl7.org/fhir/sid/icd-9', system: 'ICD-9' },
-    { url: 'http://hl7.org/fhir/sid/icd-10', system: 'ICD-10' },
-    { url: 'http://snomed.info/sct', system: 'SNOMED CT' },
-    { url: 'http://loinc.org', system: 'LOINC' },
-    { url: 'http://www.hl7.org/FHIR/valueset-dicom-dcim.html', system: 'DCM' },
-    { url: 'http://unitsofmeasure.org', system: 'UCUM' },
-    { url: 'http://www.radlex.org/', system: 'RadLex' },
-    { url: 'http://www.whocc.no/atc', system: 'WHO' },
-    { url: 'urn:std:iso:11073:10101', system: 'ISO 11073-10101' }
-  ],
+  // codingSystems: [
+  //   { url: 'http://hl7.org/fhir/sid/icd-9', system: 'ICD-9' },
+  //   { url: 'http://hl7.org/fhir/sid/icd-10', system: 'ICD-10' },
+  //   { url: 'http://snomed.info/sct', system: 'SNOMED CT' },
+  //   { url: 'http://loinc.org', system: 'LOINC' },
+  //   { url: 'http://www.hl7.org/FHIR/valueset-dicom-dcim.html', system: 'DCM' },
+  //   { url: 'http://unitsofmeasure.org', system: 'UCUM' },
+  //   { url: 'http://www.radlex.org/', system: 'RadLex' },
+  //   { url: 'http://www.whocc.no/atc', system: 'WHO' },
+  //   { url: 'urn:std:iso:11073:10101', system: 'ISO 11073-10101' },
+  //   { url: 'http://www.ama-assn.org/go/cpt', system: 'CPT' }
+  // ],
 
   selectedCodingSystem: null,
 

--- a/app/styles/_application.scss
+++ b/app/styles/_application.scss
@@ -1,8 +1,9 @@
 /* -------------------------------- DOM -------------------------------- */
 
 body {
-   font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-   font-weight: 300;
+  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-weight: 300;
+  padding-bottom: 2em;
 }
 
 h1 {

--- a/app/templates/components/add-to-huddle-modal.hbs
+++ b/app/templates/components/add-to-huddle-modal.hbs
@@ -44,7 +44,7 @@
           </div>
         </div>
 
-        <div class="form-group">
+        {{!-- <div class="form-group">
           <div class="row">
             <div class="col-sm-4">
               <label for="huddleLeader">Leader:</label>
@@ -61,7 +61,7 @@
                 disabled={{huddleLeaderDisabled}}>
             </div>
           </div>
-        </div>
+        </div> --}}
       </div>
 
       <div class="modal-footer">

--- a/app/templates/components/age-filter.hbs
+++ b/app/templates/components/age-filter.hbs
@@ -13,14 +13,15 @@
   <div class="form-group">
     {{#if active}}
       <div class="selected-filter-details">
-        <span class="pane-inner-label">in</span>
+        {{!-- <span class="pane-inner-label">in</span>
         <span class="pane-select">
           {{select-fx options=timePeriods value=selectedTimePeriod onChange=(action "selectTimePeriod")}}
         </span>
         <span class="pane-inner-label">is</span>
         <span class="pane-select">
           {{select-fx options=comparators value=selectedComparator onChange=(action "selectComparator")}}
-        </span>
+        </span> --}}
+        <span class="pane-inner-label">in years is between</span>
         <span class="pane-input">
           <input type="text" value={{lowValue}} class="input-control age" onchange={{action "updateValue" "lowValue"}}>
         </span>

--- a/app/templates/components/filter-counts.hbs
+++ b/app/templates/components/filter-counts.hbs
@@ -32,8 +32,8 @@
     </span><br/>
     <span>encounters</span>
   </div>
-  <div class="time-selection col-sm-3">
+  {{!-- <div class="time-selection col-sm-3">
     <span>in the last</span><br/>
     <span class="time-period">{{timeSpan}}</span>
-  </div>
+  </div> --}}
 </div>

--- a/app/templates/components/ie-navbar.hbs
+++ b/app/templates/components/ie-navbar.hbs
@@ -18,9 +18,9 @@
   <div class="collapse navbar-collapse navbar-ex1-collapse">
     <ul class="nav navbar-nav navbar-right">
       {{#navbar-active-link}}{{#link-to "patients"}}<i class="fa fa-user"></i> Patients{{/link-to}}{{/navbar-active-link}}
-      {{#navbar-active-link}}{{#link-to "index"}}<i class="fa fa-users"></i> Populations{{/link-to}}{{/navbar-active-link}}
+      {{!-- {{#navbar-active-link}}{{#link-to "index"}}<i class="fa fa-users"></i> Populations{{/link-to}}{{/navbar-active-link}} --}}
       {{#navbar-active-link}}{{#link-to "filters.new"}}<i class="fa fa-filter"></i> Filter Builder{{/link-to}}{{/navbar-active-link}}
-      {{#navbar-active-link}}{{#link-to utilities}}<i class="fa fa-cogs"></i> Utilities{{/link-to}}{{/navbar-active-link}}
+      {{!-- {{#navbar-active-link}}{{#link-to utilities}}<i class="fa fa-cogs"></i> Utilities{{/link-to}}{{/navbar-active-link}} --}}
       {{#if session.isAuthenticated}}
         <li><a href="#" onclick={{action 'invalidateSession'}} class="navbar-right"><i class="fa fa-sign-out"></i> Logout</a></li>
       {{else}}

--- a/app/templates/components/patient-badge.hbs
+++ b/app/templates/components/patient-badge.hbs
@@ -23,10 +23,10 @@
               <i class="fa {{genderIconClassName}}"></i>
               {{patient.computedGender}}
             </span>
-            <span class="patient-location">
+            {{!-- <span class="patient-location">
               <i class="fa fa-map-marker"></i>
               {{patient.location}}
-            </span>
+            </span> --}}
           </div>
         </div>
         <div class="col-xs-6">

--- a/app/templates/components/patient-search/risk-assessment.hbs
+++ b/app/templates/components/patient-search/risk-assessment.hbs
@@ -10,7 +10,7 @@
           checked={{eq currentAssessment riskAssessment}}
           onchange={{action attrs.selectRiskAssessment value="target.value"}}>
         <label for={{concat riskAssessment index}} class="css-label css-label-circle checkbox-label">{{riskAssessment}}</label>
-        <i class="fa fa-edit pull-right"></i>
+        {{!-- <i class="fa fa-edit pull-right"></i> --}}
       </div>
     {{/if}}
   {{/each}}

--- a/app/templates/components/patient-stats.hbs
+++ b/app/templates/components/patient-stats.hbs
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<div class="panel-heading">
+{{!-- <div class="panel-heading">
   <div class="collapse-panel-title">
     <a data-toggle="collapse" href="#interventions" aria-expanded="true" aria-controls="collapseOne">
       <i class="fa fa-user-md fa-fw"></i>
@@ -28,14 +28,13 @@
 </div>
 <div class="panel-body">
   <div class="collapse in" id="interventions">
-    {{!-- TODO --}}
     <div class="add-new-filter-lg">
       <button type="button" class="btn btn-link" onclick={{action attrs.openAddInterventionModal}}>
         <i class="fa fa-plus-circle"></i> add new
       </button>
     </div>
   </div>
-</div>
+</div> --}}
 
 <div class="panel-heading">
   <div class="collapse-panel-title">
@@ -79,7 +78,7 @@
   </div>
 </div>
 
-<div class="panel-heading">
+{{!-- <div class="panel-heading">
   <div class="collapse-panel-title">
     <a data-toggle="collapse" href="#allergies" aria-expanded="true" aria-controls="collapseOne">
       <i class="fa fa-pagelines fa-fw"></i>
@@ -90,6 +89,6 @@
 </div>
 <div class="panel-body">
   <div class="collapse in" id="allergies">
-    {{!-- TODO --}}
+
   </div>
-</div>
+</div> --}}

--- a/app/templates/components/patient-stats.hbs
+++ b/app/templates/components/patient-stats.hbs
@@ -1,4 +1,4 @@
-<div class="panel-heading">
+{{!-- <div class="panel-heading">
   <div class="collapse-panel-title">
     <a data-toggle="collapse" href="#appointments" aria-expanded="true" aria-controls="collapseOne">
       <i class="fa fa-hospital-o fa-fw"></i>
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-{{!-- <div class="panel-heading">
+<div class="panel-heading">
   <div class="collapse-panel-title">
     <a data-toggle="collapse" href="#interventions" aria-expanded="true" aria-controls="collapseOne">
       <i class="fa fa-user-md fa-fw"></i>

--- a/app/templates/components/patient-summary.hbs
+++ b/app/templates/components/patient-summary.hbs
@@ -26,10 +26,10 @@
           {{patient.computedGender}}
         </span>
 
-        <span class="patient-location">
+        {{!-- <span class="patient-location">
           <i class="fa fa-map-marker"></i>
           {{patient.location}}
-        </span>
+        </span> --}}
 
         {{#if huddle}}
           <span class="patient-next-huddle">

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -28,7 +28,7 @@
                     checked={{eq currentAssessment riskAssessment}}
                     onchange={{action attrs.setRiskAssessment value="target.value"}}>
                   <label for={{concat riskAssessment index}} class="css-label css-label-circle checkbox-label">{{riskAssessment}}</label>
-                  <i class="fa fa-edit pull-right"></i>
+                  {{!-- <i class="fa fa-edit pull-right"></i> --}}
                 </div>
               {{/if}}
             {{/each}}
@@ -67,7 +67,7 @@
                   <div class="meta">
                     {{#if selectedScheduleHuddle}}
                       Geriatrics Huddle<br>
-                      Leader: {{selectedScheduleHuddle.displayLeader}}<br>
+                      {{!-- Leader: {{selectedScheduleHuddle.displayLeader}}<br> --}}
                       {{selectedScheduleHuddlePatient.reasonText}}
                       {{#if selectedScheduleHuddlePatient.reviewed}}
                         <br>

--- a/app/templates/components/review-patient-modal.hbs
+++ b/app/templates/components/review-patient-modal.hbs
@@ -37,7 +37,7 @@
         </div>
       </div>
 
-      <div class="form-group">
+      {{!-- <div class="form-group">
         <div class="form-control-static row">
           <div class="col-sm-6">
             <label>Leader:</label>
@@ -47,7 +47,7 @@
             {{huddle.displayLeader}}
           </div>
         </div>
-      </div>
+      </div> --}}
 
       <div class="form-group">
         <div class="row">

--- a/app/templates/patients/index.hbs
+++ b/app/templates/patients/index.hbs
@@ -5,7 +5,7 @@
     {{/nested-panel}}
     {{#nested-panel panelName="Choose Filters" panelId="chooseFilters"}}
       {{patient-search/population-filter populations=populations selectedPopulation=selectedPopulation togglePopulation=(action "togglePopulation")}}
-      {{patient-search/risk-score lowValue=riskLowValue highValue=riskHighValue onChange=(action "setRiskScore")}}
+      {{!-- {{patient-search/risk-score lowValue=riskLowValue highValue=riskHighValue onChange=(action "setRiskScore")}} --}}
       {{patient-search/huddle-list huddles=model.huddles selectedHuddle=selectedHuddle selectHuddle=(action 'selectHuddle')}}
     {{/nested-panel}}
     {{#nested-panel panelName="Choose Sort By" panelId="chooseSortBy"}}


### PR DESCRIPTION
# Removed UI Features Not Supported in Pilot
-   Removed (via comment-out) the following features:
  -   Location sort and patient badge display
  -   Risk Score filter and sort
  -   Notifications sort
  -   Huddle Leader
  -   Filter Builder age filter comparators and time periods and replaced with "in years is between"
  -   Filter Builder counter time period
  -   Filter Builder conditions coding systems limited to ICD-9 and ICD-10
  -   Filter Builder encounters coding systems limited to SNOMED-CT and CPT
  -   Risk assessment edit button
  -   Populations and Utilities Navbar links
  -   Appointments display in patient view
  -   Allergies display in patient view
-   Removed `Stroke` and `Negative Outcome` risk assessments.
-   Added `Catastrophic Health Event` mock RedCap risk assessment.
##### TODO:
- [ ] Hook up ICD-9 codes for Filter Builder conditions.
- [ ] Hook up CPT codes for Filter Builder encounters.
- [ ] Implement autocomplete for Filter Builder encounters.
- [ ] Fix responsive CSS
##### Screenshots:

![screen shot 2016-04-22 at 9 33 52 am](https://cloud.githubusercontent.com/assets/5418735/14743200/61fb15d4-086e-11e6-9977-b65138e1325a.png)

![screen shot 2016-04-22 at 9 34 11 am](https://cloud.githubusercontent.com/assets/5418735/14743204/68117ada-086e-11e6-80d5-27bf1473c6c3.png)

![screen shot 2016-04-22 at 9 42 15 am](https://cloud.githubusercontent.com/assets/5418735/14743221/859a845c-086e-11e6-8e39-8f2c10c0df98.png)
