### PR TITLE
Added Huddle Reason Textfield to Manually Added Huddles

### DIFF
--- a/app/components/add-to-huddle-modal.js
+++ b/app/components/add-to-huddle-modal.js
@@ -29,9 +29,24 @@ export default Component.extend(HasStylesheetMixin, {
       return '';
     }
   }),
+  huddleReasonText: computed('huddle', {
+    get() {
+      let huddle = this.get('huddle');
+      if (huddle != null) {
+        return huddle.getHuddlePatient(this.get('patient')).get('reasonText');
+      }
+      return '';
+    }
+  }),
   patient: null,
   isLoading: true,
   huddleLeaderDisabled: computed.notEmpty('existingHuddle'),
+  huddleReasonTextDisabled: computed('huddle', 'huddleDate', {
+    get() {
+      let huddle = this.get('huddle');
+      return huddle != null && moment(this.get('huddleDate')).isSame(huddle.get('date'), 'day');
+    }
+  }),
   formSaving: false,
   saveBtnDisabled: computed.or('formSaving', 'patientInExistingHuddle'),
   removeBtnDisabled: computed.alias('formSaving'),
@@ -147,7 +162,7 @@ export default Component.extend(HasStylesheetMixin, {
         newHuddle = true;
       }
 
-      huddle.addPatient(patient);
+      huddle.addPatient(patient, this.get('huddleReasonText'));
 
       let url = newHuddle ? '/Group' : `/Group/${huddle.get('id')}`;
       let type = newHuddle ? 'POST' : 'PUT';

--- a/app/components/huddle-reason-icon.js
+++ b/app/components/huddle-reason-icon.js
@@ -15,7 +15,7 @@ export default Component.extend({
     this.$().tooltip({
       container: 'body',
       title: () => {
-        return this.get('huddlePatient.reasonText');
+        return this.get('huddlePatient.displayReasonText');
       }
     });
   },

--- a/app/components/huddle-reason-icon.js
+++ b/app/components/huddle-reason-icon.js
@@ -15,7 +15,7 @@ export default Component.extend({
     this.$().tooltip({
       container: 'body',
       title: () => {
-        return this.get('huddlePatient.displayReasonText');
+        return this.get('huddlePatient.codedReasonText');
       }
     });
   },

--- a/app/models/huddle-patient.js
+++ b/app/models/huddle-patient.js
@@ -1,4 +1,6 @@
 import EmberObject from 'ember-object';
+import computed from 'ember-computed';
+import { isEmpty } from 'ember-utils';
 import moment from 'moment';
 
 export const REASON_CODES = {
@@ -15,6 +17,18 @@ export default EmberObject.extend({
   reason: null,
   reasonText: null,
   reviewed: null,
+
+  displayReasonText: computed('reason', 'reasonText', {
+    get() {
+      let reasonText = this.get('reasonText');
+
+      if (this.get('reason') === REASON_CODES.MANUAL_ADDITION) {
+        return `Manually Added${isEmpty(reasonText) ? '' : ` - ${reasonText}`}`;
+      }
+
+      return reasonText;
+    }
+  }).readOnly(),
 
   toFhirJson() {
     let obj = {

--- a/app/models/huddle-patient.js
+++ b/app/models/huddle-patient.js
@@ -18,6 +18,16 @@ export default EmberObject.extend({
   reasonText: null,
   reviewed: null,
 
+  codedReasonText: computed('reason', 'reasonText', {
+    get() {
+      if (this.get('reason') === REASON_CODES.MANUAL_ADDITION) {
+        return 'Manually Added';
+      }
+
+      return this.get('reasonText');
+    }
+  }).readOnly(),
+
   displayReasonText: computed('reason', 'reasonText', {
     get() {
       let reasonText = this.get('reasonText');

--- a/app/models/huddle.js
+++ b/app/models/huddle.js
@@ -27,11 +27,11 @@ const Huddle = EmberObject.extend({
     }
   }).readOnly(),
 
-  addPatient(patient) {
+  addPatient(patient, reasonText) {
     let huddlePatient = HuddlePatient.create({
       patientId: patient.get('id'),
       reason: 'MANUAL_ADDITION',
-      reasonText: 'Manually Added'
+      reasonText: reasonText
     });
     this.get('patients').pushObject(huddlePatient);
   },

--- a/app/models/huddle.js
+++ b/app/models/huddle.js
@@ -28,12 +28,21 @@ const Huddle = EmberObject.extend({
   }).readOnly(),
 
   addPatient(patient, reasonText) {
-    let huddlePatient = HuddlePatient.create({
-      patientId: patient.get('id'),
-      reason: 'MANUAL_ADDITION',
-      reasonText: reasonText
-    });
-    this.get('patients').pushObject(huddlePatient);
+    let huddlePatient = this.getHuddlePatient(patient);
+
+    if (huddlePatient != null) {
+      huddlePatient.setProperties({
+        reason: 'MANUAL_ADDITION',
+        reasonText
+      });
+    } else {
+      huddlePatient = HuddlePatient.create({
+        patientId: patient.get('id'),
+        reason: 'MANUAL_ADDITION',
+        reasonText
+      });
+      this.get('patients').pushObject(huddlePatient);
+    }
   },
 
   removePatient(patient) {

--- a/app/styles/_patient-viewer.scss
+++ b/app/styles/_patient-viewer.scss
@@ -64,6 +64,15 @@
     display: block;
     text-align: right;
   }
+
+  textarea {
+    width: 100%;
+  }
+
+  textarea[disabled] {
+    cursor: not-allowed;
+    background-color: #eee;
+  }
 }
 
 .is-today .pika-button {

--- a/app/templates/components/add-to-huddle-modal.hbs
+++ b/app/templates/components/add-to-huddle-modal.hbs
@@ -62,6 +62,17 @@
             </div>
           </div>
         </div>
+
+        <div class="form-group">
+          <div class="row">
+            <div class="col-sm-4">
+              <label for="huddleReason">Reason:</label>
+            </div>
+            <div class="col-sm-8">
+              {{textarea elementId="huddleReason" rows=3 value=huddleReasonText disabled=huddleReasonTextDisabled}}
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="modal-footer">

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -68,7 +68,7 @@
                     {{#if selectedScheduleHuddle}}
                       Geriatrics Huddle<br>
                       Leader: {{selectedScheduleHuddle.displayLeader}}<br>
-                      {{selectedScheduleHuddlePatient.reasonText}}
+                      {{selectedScheduleHuddlePatient.displayReasonText}}
                       {{#if selectedScheduleHuddlePatient.reviewed}}
                         <br>
                         Discussed on {{moment-format selectedScheduleHuddlePatient.reviewed 'MMM D, YYYY'}}


### PR DESCRIPTION
# Added Huddle Reason Textfield to Manually Added Huddles
-   Added support for specifying the reason a patient is being manually added to a huddle.
-      Added support for editing the reason a patient is being manually added to a huddle.
##### Screenshots:

![screen shot 2016-04-22 at 10 19 39 am](https://cloud.githubusercontent.com/assets/5418735/14744310/45b671ce-0874-11e6-825a-4cc52d5ad856.png)

![screen shot 2016-04-22 at 10 20 30 am](https://cloud.githubusercontent.com/assets/5418735/14744314/4ccf7a6e-0874-11e6-8839-85d4fc17042a.png)
