### PR TITLE
Fixed CSS styles for Desktop-wide, Desktop, and Tablet Sizes

### DIFF
--- a/app/components/filter-counts.js
+++ b/app/components/filter-counts.js
@@ -4,7 +4,7 @@ import service from 'ember-service/inject';
 import run from 'ember-runloop';
 
 export default Component.extend({
-  classNames: ['filter-counts', 'col-sm-8'],
+  classNames: ['filter-counts'],
 
   ajax: service(),
 

--- a/app/components/patient-badge.js
+++ b/app/components/patient-badge.js
@@ -43,8 +43,9 @@ export default Component.extend(PatientIconClassNames, {
     }
 
     let riskBar = this.element.querySelector('.patient-risk-bar');
+
     if (riskBar) {
-      let width = Math.floor(this.get('computedRisk') * this.get('maxRisk') * 3);
+      let width = Math.floor(100 / this.get('maxRisk') * this.get('computedRisk'));
       riskBar.style.width = `${width}%`;
     }
   },

--- a/app/components/patient-risk-chart.js
+++ b/app/components/patient-risk-chart.js
@@ -20,7 +20,7 @@ export default C3Chart.extend({
 
     // group data by dates
     let nestedData = d3.nest()
-      .key((d) =>moment(d.get('date')).toDate())
+      .key((d) => moment(d.get('date')).toDate())
       .entries(data);
 
     let labels = nestedData.map((value) => {

--- a/app/styles/_application.scss
+++ b/app/styles/_application.scss
@@ -141,3 +141,4 @@ svg {
 .cursor-pointer {
   cursor: pointer;
 }
+

--- a/app/styles/_filters.scss
+++ b/app/styles/_filters.scss
@@ -1,3 +1,12 @@
+.filter-builder-container {
+  // @include respond-to(tablet) {
+  //   position: absolute;
+  //   left: 10px;
+  //   padding: 0;
+  //   width: 750px;
+  // }
+}
+
 /* -------------------------------- LIST -------------------------------- */
 
 .filterList {
@@ -14,6 +23,7 @@
 
   .count {
     min-width: 150px;
+    margin: 0;
 
     .count-value {
       display: inline-block;
@@ -102,12 +112,13 @@
     .pane-input input {
       padding-left: 10px;
       height: 45px;
-      width: 325px;
+      width: 350px;
       font-size: 20px;
+      margin: 15px;
     }
 
     button {
-      margin: 0 1px 5px 10px;
+      margin: 5px 1px 5px 10px;
     }
   }
 }

--- a/app/styles/_filters.scss
+++ b/app/styles/_filters.scss
@@ -1,12 +1,3 @@
-.filter-builder-container {
-  // @include respond-to(tablet) {
-  //   position: absolute;
-  //   left: 10px;
-  //   padding: 0;
-  //   width: 750px;
-  // }
-}
-
 /* -------------------------------- LIST -------------------------------- */
 
 .filterList {

--- a/app/styles/_forms.scss
+++ b/app/styles/_forms.scss
@@ -95,7 +95,6 @@ input[type=radio].css-checkbox {
 input[type=checkbox].css-checkbox + label.css-label,
 input[type=radio].css-checkbox + label.css-label {
   display: inline-block;
-  // height: 30px;
   line-height: 30px;
   background-repeat: no-repeat;
   background-position: 0 0;

--- a/app/styles/_forms.scss
+++ b/app/styles/_forms.scss
@@ -268,7 +268,7 @@ input:-webkit-autofill:focus {
 
 .sliding-search:focus,
 .sliding-search.expanded {
-  width: 180px;
+  width: 300px;
   padding-left: 20px;
   color: #000;
   background-color: #fff;

--- a/app/styles/_forms.scss
+++ b/app/styles/_forms.scss
@@ -95,7 +95,7 @@ input[type=radio].css-checkbox {
 input[type=checkbox].css-checkbox + label.css-label,
 input[type=radio].css-checkbox + label.css-label {
   display: inline-block;
-  height: 30px;
+  // height: 30px;
   line-height: 30px;
   background-repeat: no-repeat;
   background-position: 0 0;
@@ -268,7 +268,7 @@ input:-webkit-autofill:focus {
 
 .sliding-search:focus,
 .sliding-search.expanded {
-  width: 300px;
+  width: 250px;
   padding-left: 20px;
   color: #000;
   background-color: #fff;

--- a/app/styles/_panes.scss
+++ b/app/styles/_panes.scss
@@ -17,6 +17,14 @@
     height: 100px;
     margin: 0 15px 0 0;
     text-align: center;
+
+    @include respond-to(tablet) {
+      font-size: 1.5em;
+      width: 50px;
+      height: 50px;
+      padding: 2px 0;
+      margin: 20px 10px 0 -8px;
+    }
   }
 
   .pane-content {
@@ -65,6 +73,7 @@
 
 .pane-input input {
   padding: 0;
+  margin: 0;
   border: 1px solid lighten($brand-secondary, 20%);
 
   &.age {
@@ -74,7 +83,9 @@
 
   &.condition,
   &.encounter {
-    width: 245px;
+    width: 600px;
     padding-left: 10px;
+
+    @include respond-to(tablet) { width: 230px; }
   }
 }

--- a/app/styles/_patient-viewer.scss
+++ b/app/styles/_patient-viewer.scss
@@ -1,5 +1,7 @@
 #patientViewerPikaday {
   padding-top: 0.5em;
+  width: 258px;
+  margin: 0 auto;
 }
 
 #patientViewerPikadayCalendar .pika-single {

--- a/app/styles/_patients.scss
+++ b/app/styles/_patients.scss
@@ -72,6 +72,7 @@
           }
 
           .patient-name {
+            margin-left: 10px;
             font-size: 24px;
           }
 
@@ -82,7 +83,7 @@
             .patient-age,
             .patient-gender,
             .patient-location {
-              margin-right: 1em;
+              margin: 0 12px;
             }
           }
 
@@ -94,7 +95,7 @@
 
             @include respond-to(desktop-wide) { width: 350px; }
             @include respond-to(desktop) { width: 200px; }
-            @include respond-to(tablet) { width: 85px; }
+            @include respond-to(tablet) { width: 150px; }
             @include respond-to(mobile) { width: 250px; }
 
             .patient-risk-bar {
@@ -135,6 +136,16 @@
           }
         }
       }
+    }
+  }
+
+  // ----------------------- PATIENT SHOW ---------------------------------- //
+
+  .patient-show {
+    @include respond-to(tablet) {
+      position: absolute;
+      left: 10px;
+      padding: 0;
     }
   }
 

--- a/app/styles/_patients.scss
+++ b/app/styles/_patients.scss
@@ -92,8 +92,8 @@
             right: 0;
             height: 24px;
 
-            @include respond-to(desktop-wide) { width: 175px; }
-            @include respond-to(desktop) { width: 175px; }
+            @include respond-to(desktop-wide) { width: 350px; }
+            @include respond-to(desktop) { width: 200px; }
             @include respond-to(tablet) { width: 85px; }
             @include respond-to(mobile) { width: 250px; }
 
@@ -265,9 +265,9 @@
 
   .aster-plot {
     margin: 0 auto;
-    padding: 20px;
-    @include respond-to(desktop) { padding: 20px 5px; }
-    @include respond-to(tablet) { width: 400px; }
+    padding: 10px;
+    width: 400px;
+    @include respond-to(desktop) { width: 315px; }
 
     .category {
       cursor: pointer;
@@ -275,8 +275,8 @@
   }
 
   .category-details {
+    margin: auto;
     font-size: 18px;
-    @include respond-to(desktop-wide) { width: 450px; }
     @include respond-to(tablet) {
       width: 400px;
       margin: 0 auto 30px auto;
@@ -288,8 +288,20 @@
       padding: 10px;
     }
 
-    .category-stat-value {
-      font-weight: 500;
+    .category-stat {
+      margin: auto;
+      @include respond-to(desktop-wide) { width: 80%; }
+
+      .category-stat-label {
+        text-align: right;
+        line-height: 30px;
+      }
+
+      .category-stat-value {
+        font-size: 1.2em;
+        font-weight: 500;
+        text-align: right;
+      }
     }
 
     .sub-text {

--- a/app/styles/_search.scss
+++ b/app/styles/_search.scss
@@ -1,5 +1,4 @@
 .search {
-  // display: inline-block;
   margin: 15px auto;
   padding: 0 10px;
   border: 1px solid lighten($brand-secondary, 60%);
@@ -32,8 +31,7 @@
   }
 
   &.search-timeline {
-    // width: 85%;
-    margin-left: 35px;
+    margin-left: 70px;
   }
 }
 

--- a/app/styles/_search.scss
+++ b/app/styles/_search.scss
@@ -1,7 +1,7 @@
 .search {
   margin: 15px auto;
   padding: 0 10px;
-  border: 1px solid lighten($brand-secondary, 60%);
+  border: 1px solid lighten($brand-secondary, 50%);
   border-radius: 15px;
   height: 28px;
   font-size: 16px;
@@ -20,7 +20,6 @@
 
   .form-control {
     height: 25px;
-    // width: 180px;
     padding-left: 10px;
     color: $brand-secondary;
   }
@@ -34,5 +33,3 @@
     margin-left: 70px;
   }
 }
-
-

--- a/app/styles/_timeline.scss
+++ b/app/styles/_timeline.scss
@@ -1,4 +1,10 @@
 // ------------------------- TIMELINE -------------------------------------- //
+.patient-timeline-wide-container {
+  clear: both;
+  margin: 40px;
+  padding-top: 20px;
+}
+
 .timeline {
   margin: 0 10px 0 30px;
 

--- a/app/styles/_timeline.scss
+++ b/app/styles/_timeline.scss
@@ -1,8 +1,6 @@
 // ------------------------- TIMELINE -------------------------------------- //
 .timeline {
-  margin: 20px auto;
-  @include respond-to(desktop) { margin: 20px 0 0 80px; }
-  @include respond-to(tablet) { margin: 20px 0 0 80px; }
+  margin: 0 10px 0 30px;
 
   .timeline-icon-search {
     .timeline-icon {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -6,8 +6,6 @@ $brand-alert: #E2495C;      // custom - red
 $body-bg: #EEEEEE;          // light gray
 $body-bg-inverse: #FFFFFF;  // white
 $headings-color: $brand-secondary;
-// $btn-default-bg: $brand-primary;
-// $navbar-inverse-bg: $brand-secondary;
 $navbar-inverse-bg: #454545;
 $navbar-inverse-color: $body-bg-inverse;
 $navbar-inverse-link-color: $navbar-inverse-color;

--- a/app/templates/components/category-details.hbs
+++ b/app/templates/components/category-details.hbs
@@ -1,34 +1,40 @@
-<div class="row category-details">
-  <div class="col-xs-12 category-name">
+<div class="category-details">
+  <div class="category-name">
     {{category.name}}
   </div>
 
-  <div class="category-stat">
-    <div class="col-lg-3 col-md-4 col-xs-3">
+  <div class="category-stat row">
+    <div class="category-stat-label col-lg-2 col-md-3 col-xs-3">
       Risk:
     </div>
+
     <div class="col-lg-2 col-md-3 col-xs-2 category-stat-value">
       {{category.value}}
     </div>
-    <div class="col-lg-7 hidden-md col-xs-7">
-      {{horizontal-bar-chart max=category.maxValue width=200 height=5 value=category.value}}
+
+    <div class="col-lg-8 hidden-md col-xs-7">
+      {{horizontal-bar-chart max=category.maxValue width=300 height=5 value=category.value}}
     </div>
-    <div class="col-md-5 hidden-lg hidden-sm hidden-xs">
+
+    <div class="col-md-6 hidden-lg hidden-sm hidden-xs">
       {{horizontal-bar-chart max=category.maxValue width=100 height=5 value=category.value}}
     </div>
   </div>
 
-  <div class="category-stat">
-    <div class="col-lg-3 col-md-4 col-xs-3">
+  <div class="category-stat row">
+    <div class="category-stat-label col-lg-2 col-md-3 col-xs-3">
       Weight:
     </div>
+
     <div class="col-lg-2 col-md-3 col-xs-2 category-stat-value">
       {{category.weight}}
     </div>
-    <div class="col-lg-7 hidden-md col-xs-7">
-      {{horizontal-bar-chart max=category.maxWeight width=200 height=5 value=category.weight}}
+
+    <div class="col-lg-8 hidden-md col-xs-7">
+      {{horizontal-bar-chart max=category.maxWeight width=300 height=5 value=category.weight}}
     </div>
-    <div class="col-md-5 hidden-lg hidden-sm hidden-xs">
+
+    <div class="col-md-6 hidden-lg hidden-sm hidden-xs">
       {{horizontal-bar-chart max=category.maxWeight width=100 height=5 value=category.weight}}
     </div>
   </div>

--- a/app/templates/components/category-details.hbs
+++ b/app/templates/components/category-details.hbs
@@ -12,12 +12,12 @@
       {{category.value}}
     </div>
 
-    <div class="col-lg-8 hidden-md col-xs-7">
+    <div class="col-lg-8 hidden-md hidden-sm col-xs-7">
       {{horizontal-bar-chart max=category.maxValue width=300 height=5 value=category.value}}
     </div>
 
-    <div class="col-md-6 hidden-lg hidden-sm hidden-xs">
-      {{horizontal-bar-chart max=category.maxValue width=100 height=5 value=category.value}}
+    <div class="col-md-6 col-sm-7 hidden-lg hidden-xs">
+      {{horizontal-bar-chart max=category.maxValue width=150 height=5 value=category.value}}
     </div>
   </div>
 
@@ -30,12 +30,12 @@
       {{category.weight}}
     </div>
 
-    <div class="col-lg-8 hidden-md col-xs-7">
+    <div class="col-lg-8 hidden-md hidden-sm col-xs-7">
       {{horizontal-bar-chart max=category.maxWeight width=300 height=5 value=category.weight}}
     </div>
 
-    <div class="col-md-6 hidden-lg hidden-sm hidden-xs">
-      {{horizontal-bar-chart max=category.maxWeight width=100 height=5 value=category.weight}}
+    <div class="col-md-6 col-sm-6 hidden-lg hidden-xs">
+      {{horizontal-bar-chart max=category.maxWeight width=150 height=5 value=category.weight}}
     </div>
   </div>
 </div>

--- a/app/templates/components/filter-builder.hbs
+++ b/app/templates/components/filter-builder.hbs
@@ -1,11 +1,11 @@
 <div class="container">
   <div class="title-panel row">
-    <div class="title-text col-sm-4">Filter Builder</div>
-    {{filter-counts group=group}}
+    <div class="title-text col-md-4 col-sm-12">Filter Builder</div>
+    <div class="col-md-8 col-sm-12">{{filter-counts group=group}}</div>
   </div>
 
-  <div class="row">
-    <div class="col-sm-3">
+  <div class="row filter-builder-container">
+    <div class="col-md-3 col-sm-5">
       <div class="panel">
         <div class="panel-heading">
           <div class="panel-title">
@@ -57,7 +57,7 @@
       </div>
     </div>
 
-    <div class="col-sm-9">
+    <div class="col-md-9 col-sm-7">
       <div class="panel">
         <div class="panel-heading">
           <div class="panel-title">
@@ -71,11 +71,15 @@
               {{#each panes as |pane|}}
                 {{filter-pane pane=pane group=group onChange=(action "updateCounts") removePane=(action "removePane")}}
               {{/each}}
-              <div class="save-new-filter">
-                <span class="pane-input">
+
+              <div class="save-new-filter row">
+                <div class="pane-input">
                   {{input type="text" value=filterName placeholder="name of filter"}}
-                </span>
-                <button class="btn btn-lg btn-primary" {{action "saveFilter"}}>Save Filter</button>
+                </div>
+
+                <div class="col-sm-12">
+                  <button class="btn btn-lg btn-primary pull-right" {{action "saveFilter"}}>Save Filter</button>
+                </div>
               </div>
             {{else}}
               <span class="sub-text">

--- a/app/templates/components/filter-counts.hbs
+++ b/app/templates/components/filter-counts.hbs
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="count col-sm-3">
+  <div class="count col-sm-4">
     <span class="count-value" id="patient-count">
       {{#if loading}}
         {{ember-spinner config='small' top='30%'}}
@@ -10,7 +10,8 @@
     </span><br/>
     <span>patients</span>
   </div>
-  <div class="count col-sm-3">
+
+  <div class="count col-sm-4">
     <span class="count-value" id="condition-count">
       {{#if loading}}
         {{ember-spinner config='small' top='30%'}}
@@ -21,7 +22,8 @@
     </span><br/>
     <span>conditions</span>
   </div>
-  <div class="count col-sm-3">
+
+  <div class="count col-sm-4">
     <span class="count-value" id="encounter-count">
       {{#if loading}}
         {{ember-spinner config='small' top='30%'}}

--- a/app/templates/components/filter-pane.hbs
+++ b/app/templates/components/filter-pane.hbs
@@ -1,4 +1,4 @@
-<div class="col-xs-2 pane-icon">
+<div class="col-sm-2 pane-icon">
   <i class="fa fa-fw {{icon}}"></i>
 </div>
 

--- a/app/templates/components/gender-filter.hbs
+++ b/app/templates/components/gender-filter.hbs
@@ -13,19 +13,19 @@
   <div class="form-group">
     {{#if active}}
       <div class="row selected-filter-details">
-        <div class="col-xs-3">
+        <div class="col-md-3">
           {{radio-button radioClass="input-control css-checkbox" radioId="male" groupValue=genderValue value="male"}}
           <label class="css-label css-label-circle radio-label" for="male">male</label>
         </div>
-        <div class="col-xs-3">
+        <div class="col-md-3">
           {{radio-button radioClass="input-control css-checkbox" radioId="female" groupValue=genderValue value="female"}}
           <label class="css-label css-label-circle radio-label" for="female">female</label>
         </div>
-        <div class="col-xs-3">
+        <div class="col-md-3">
           {{radio-button radioClass="input-control css-checkbox" radioId="other" groupValue=genderValue value="other"}}
           <label class="css-label css-label-circle radio-label" for="other">other</label>
         </div>
-        <div class="col-xs-3">
+        <div class="col-md-3">
           {{radio-button radioClass="input-control css-checkbox" radioId="unknown" groupValue=genderValue value="unknown"}}
           <label class="css-label css-label-circle radio-label" for="unknown">unknown</label>
         </div>

--- a/app/templates/components/patient-badge.hbs
+++ b/app/templates/components/patient-badge.hbs
@@ -3,33 +3,39 @@
     <div class="media-left media-middle">
       <i class="fa fa-user media-object"></i>
     </div>
+
     <div class="media-body">
       <div class="row">
         <div class="patient-name col-xs-12">
           {{patient.fullName}}
+
           {{#if patient.notifications.count}}
             <span class="badge">{{patient.notifications.count}}</span>
           {{/if}}
         </div>
       </div>
+
       <div class="row">
-        <div class="col-xs-6">
+        <div class="col-md-6">
           <div class="patient-age-gender-location">
             <span class="patient-age">
               <i class={{ageIconClassName}}></i>
               {{patient.computedAge}} yrs
             </span>
+
             <span class="patient-gender">
               <i class="fa {{genderIconClassName}}"></i>
               {{patient.computedGender}}
             </span>
+
             {{!-- <span class="patient-location">
               <i class="fa fa-map-marker"></i>
               {{patient.location}}
             </span> --}}
           </div>
         </div>
-        <div class="col-xs-6">
+
+        <div class="col-md-6">
           {{#if nextHuddle}}
             <span class="patient-next-huddle">
               {{huddle-reason-icon patient=patient huddle=nextHuddle}}
@@ -39,6 +45,7 @@
           {{/if}}
         </div>
       </div>
+
       <div class="patient-risk-bar-container">
         {{#if displayRiskScore}}
           <div class="patient-risk-bar">

--- a/app/templates/components/patient-search/huddle-list.hbs
+++ b/app/templates/components/patient-search/huddle-list.hbs
@@ -2,7 +2,7 @@
   <div class="panel-heading">
     <div class="collapse-panel-title">
       <a data-toggle="collapse" href="#chooseHuddleList" aria-expanded="true" aria-controls="collapseOne">
-        Huddle List
+        Huddles
         <i class="fa fa-chevron-down pull-right"></i>
       </a>
     </div>

--- a/app/templates/components/patient-summary.hbs
+++ b/app/templates/components/patient-summary.hbs
@@ -39,11 +39,13 @@
           </span>
         {{/if}}
       </div>
+
       <div class="col-xs-5 patient-risk-chart">
         {{#if hasRisks}}
           {{patient-risk-chart chartData=risksWithBirthdayStart}}
         {{/if}}
       </div>
+
       <div class="col-xs-1">
         {{#if computedRisk}}
           <div class="patient-risk">

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -1,10 +1,9 @@
-{{patient-summary patient=patient currentAssessment=currentAssessment huddle=futureDisplayHuddle hasRisks=hasRisks}}
-
 {{!------------------------- PATIENT SUMMARY --------------------------------}}
+{{patient-summary patient=patient currentAssessment=currentAssessment huddle=futureDisplayHuddle hasRisks=hasRisks}}
 
 {{!------------------------- PATIENT STATS ----------------------------------}}
 <div class="row">
-  <div class="col-lg-2 col-sm-3 col-reset">
+  <div class="patient-view-stats col-sm-3 col-reset">
     <div class="panel">
       <div class="panel-heading">
         <div class="collapse-panel-title">
@@ -14,6 +13,7 @@
           </a>
         </div>
       </div>
+
       <div class="panel-body">
         <div class="collapse in" id="chooseRiskAssessment">
           <form class="form-horizontal form-group-striped">
@@ -35,6 +35,7 @@
           </form>
         </div>
       </div>
+
       <div class="panel-heading">
         <div class="collapse-panel-title">
           <a data-toggle="collapse" href="#huddleList" aria-expanded="true" aria-controls="collapseOne">
@@ -44,6 +45,7 @@
           </a>
         </div>
       </div>
+
       <div class="panel-body">
         <div class="collapse in" id="huddleList">
           <form class="form-horizontal form-group-striped">
@@ -89,55 +91,50 @@
     </div>
   </div>
 
-  <div class="col-lg-10 col-sm-9 {{unless hasRisks 'col-no-pad'}}">
+  <div class="patient-view-display col-sm-9 {{unless hasRisks 'col-no-pad'}}">
     {{#if hasRisks}}
       <div class="row">
 
         {{!--------------------- ASTER PLOT -------------------------------------}}
-        <div class="col-lg-8 col-md-6">
-          <div class="row">
-            <div class="col-lg-12 col-xs-12">
-              {{aster-plot-chart patient=patient data=slices selectedCategory=selectedCategory selectCategory=(action attrs.selectCategory)}}
-            </div>
+        <div class="aster-plot-container col-lg-6 col-md-5">
+          {{aster-plot-chart patient=patient data=slices selectedCategory=selectedCategory selectCategory=(action attrs.selectCategory)}}
 
-            {{!------------------- CATEGORY DETAILS -------------------------------}}
+          {{!------------------- CATEGORY DETAILS -------------------------------}}
+          {{#if selectedCategory}}
+            {{category-details category=selectedCategory}}
+          {{else}}
+            <div class="category-details">
+              <div class="category-name">
+                {{currentAssessment}}
+              </div>
 
-            <div class="col-lg-12 col-xs-12">
-              {{#if selectedCategory}}
-                {{category-details category=selectedCategory}}
-              {{else}}
-                <div class="row category-details">
-                  <div class="col-xs-12 category-name">
-                    Risk Assessment
-                  </div>
-
-                  <div class="category-stat">
-                    <div class="col-lg-3 col-md-4 col-xs-3">
-                      {{currentAssessment}}:
-                    </div>
-                    <div class="col-lg-2 col-md-3 col-xs-2 category-stat-value">
-                      {{computedRisk}}
-                    </div>
-                    <div class="col-lg-7 hidden-md col-xs-7">
-                      {{horizontal-bar-chart max=6 width=200 height=5 value=computedRisk}}
-                    </div>
-                    <div class="col-md-5 hidden-lg hidden-sm hidden-xs">
-                      {{horizontal-bar-chart max=6 width=100 height=5 value=computedRisk}}
-                    </div>
-                  </div>
-
-                  <div class="sub-text">
-                    Choose category for more detail.
-                  </div>
+              <div class="category-stat row">
+                <div class="category-stat-label col-md-2">
+                  Risk:
                 </div>
-              {{/if}}
+
+                <div class="col-lg-1 col-md-2 col-xs-2 category-stat-value">
+                  {{computedRisk}}
+                </div>
+
+                <div class="col-lg-7 hidden-md col-xs-7">
+                  {{horizontal-bar-chart max=4 width=300 height=5 value=computedRisk}}
+                </div>
+
+                <div class="col-md-5 hidden-lg hidden-sm hidden-xs">
+                  {{horizontal-bar-chart max=4 width=180 height=5 value=computedRisk}}
+                </div>
+              </div>
+
+              <div class="sub-text">
+                Choose category for more detail.
+              </div>
             </div>
-          </div>
+          {{/if}}
         </div>
 
         {{!--------------------- PATIENT TIMELINE -------------------------------}}
-
-        <div class="col-lg-4 col-md-6">
+        <div class="patient-timeline-container col-lg-6 col-md-7">
           {{patient-timeline patient=patient}}
         </div>
       </div>

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -3,12 +3,13 @@
 
 {{!------------------------- PATIENT STATS ----------------------------------}}
 <div class="row">
-  <div class="patient-view-stats col-sm-3 col-reset">
+  <div class="patient-view-stats col-md-3 col-sm-5 col-reset">
     <div class="panel">
       <div class="panel-heading">
         <div class="collapse-panel-title">
           <a data-toggle="collapse" href="#chooseRiskAssessment" aria-expanded="true" aria-controls="collapseOne">
-            Choose Risk Assessment
+            <i class="fa fa-fw fa-pie-chart" aria-hidden="true"></i>
+            Risk Assessment
             <i class="fa fa-chevron-down pull-right"></i>
           </a>
         </div>
@@ -91,7 +92,7 @@
     </div>
   </div>
 
-  <div class="patient-view-display col-sm-9 {{unless hasRisks 'col-no-pad'}}">
+  <div class="patient-view-display col-md-9 col-sm-7 {{unless hasRisks 'col-no-pad'}}">
     {{#if hasRisks}}
       <div class="row">
 
@@ -109,19 +110,19 @@
               </div>
 
               <div class="category-stat row">
-                <div class="category-stat-label col-md-2">
+                <div class="category-stat-label col-md-2 col-sm-3">
                   Risk:
                 </div>
 
-                <div class="col-lg-1 col-md-2 col-xs-2 category-stat-value">
+                <div class="col-lg-1 col-md-2 col-sm-2 col-xs-2 category-stat-value">
                   {{computedRisk}}
                 </div>
 
-                <div class="col-lg-7 hidden-md col-xs-7">
+                <div class="col-lg-7 hidden-md hidden-sm col-xs-7">
                   {{horizontal-bar-chart max=4 width=300 height=5 value=computedRisk}}
                 </div>
 
-                <div class="col-md-5 hidden-lg hidden-sm hidden-xs">
+                <div class="col-md-5 col-sm-5 hidden-lg hidden-xs">
                   {{horizontal-bar-chart max=4 width=180 height=5 value=computedRisk}}
                 </div>
               </div>
@@ -134,7 +135,7 @@
         </div>
 
         {{!--------------------- PATIENT TIMELINE -------------------------------}}
-        <div class="patient-timeline-container col-lg-6 col-md-7">
+        <div class="patient-timeline-container col-lg-6 col-md-7 hidden-sm hidden-xs">
           {{patient-timeline patient=patient}}
         </div>
       </div>
@@ -142,12 +143,18 @@
       <div class="alert alert-danger alert-full">
         {{noRiskAssessmentReason}}
       </div>
+
       <div class="row">
         <div class="col-xs-10">
           {{patient-timeline patient=patient}}
         </div>
       </div>
     {{/if}}
+  </div>
+
+  <hr />
+  <div class="patient-timeline-wide-container clearfix hidden-lg hidden-md">
+    {{patient-timeline patient=patient}}
   </div>
 </div>
 

--- a/app/templates/patients/index.hbs
+++ b/app/templates/patients/index.hbs
@@ -1,22 +1,27 @@
 <div class="row">
-  <div class="col-sm-3 patient-list-filters">
-    {{#nested-panel panelName="Choose Risk Assessment" panelId="chooseRiskAssessment"}}
+  <div class="col-md-3 col-sm-4 patient-list-filters">
+    {{#nested-panel panelName="Risk Assessment" panelId="chooseRiskAssessment"}}
       {{patient-search/risk-assessment riskAssessments=riskAssessments currentAssessment=currentAssessment selectRiskAssessment=(action "selectRiskAssessment")}}
     {{/nested-panel}}
-    {{#nested-panel panelName="Choose Filters" panelId="chooseFilters"}}
+
+    {{#nested-panel panelName="Filters" panelId="chooseFilters"}}
       {{patient-search/population-filter populations=populations selectedPopulation=selectedPopulation togglePopulation=(action "togglePopulation")}}
+
       {{!-- {{patient-search/risk-score lowValue=riskLowValue highValue=riskHighValue onChange=(action "setRiskScore")}} --}}
+
       {{patient-search/huddle-list huddles=model.huddles selectedHuddle=selectedHuddle selectHuddle=(action 'selectHuddle')}}
     {{/nested-panel}}
-    {{#nested-panel panelName="Choose Sort By" panelId="chooseSortBy"}}
+
+    {{#nested-panel panelName="Sort By" panelId="chooseSortBy"}}
       {{patient-search/sort-by sortBy=sortBy sortDescending=sortDescending selectSortBy=(action "selectSortBy")}}
     {{/nested-panel}}
   </div>
-  <div class="col-sm-9 patient-list-results">
+
+  <div class="col-md-9 col-sm-8 patient-list-results">
     <div class="panel patient-panel">
       <div class="panel-heading">
         <div class="collapse-panel-title">
-          Choose Patient ({{totalPatients}})
+          Patients ({{totalPatients}})
 
           <div class="pull-right">
             <div class="sliding-search-container">
@@ -30,6 +35,7 @@
           </div>
         </div>
       </div>
+
       <div class="panel-body">
         <div class="patient-list">
           {{#each sortedPatients as |patient|}}

--- a/app/templates/patients/show.hbs
+++ b/app/templates/patients/show.hbs
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row patient-show">
   <div class="col-xs-12">
     <div class="patient-panel">
       <div class="patient-panel-header">


### PR DESCRIPTION
# Fixed CSS styles for Desktop-wide, Desktop, and Tablet Sizes
- Fixed CSS styles for desktop-wide, desktop, and tablet sizes for patient list, patient view, and filter builder.
- Fixed bug where patient risk bar widths were not being calculated correctly.
#### TODO
- [ ] Discuss/fix CSS styles for mobile.
#### Desktop-Wide Screenshots
##### Patient List

![screen shot 2016-05-17 at 1 02 57 pm](https://cloud.githubusercontent.com/assets/5418735/15331769/de842b60-1c30-11e6-9d3c-4659aaa8b97b.png)
##### Patient View

![screen shot 2016-05-17 at 1 03 14 pm](https://cloud.githubusercontent.com/assets/5418735/15331778/e7832ba8-1c30-11e6-8210-83f8924e9dc6.png)
##### Filter Builder

![screen shot 2016-05-17 at 1 17 11 pm](https://cloud.githubusercontent.com/assets/5418735/15331956/b907d5fc-1c31-11e6-8962-14f77d00b376.png)
#### Desktop Screenshots
##### Patient List

![screen shot 2016-05-17 at 1 01 33 pm](https://cloud.githubusercontent.com/assets/5418735/15331714/9af3bb86-1c30-11e6-8d7b-a8dfe03b68aa.png)
##### Patient View

![screen shot 2016-05-17 at 1 01 47 pm](https://cloud.githubusercontent.com/assets/5418735/15331721/a46ec17e-1c30-11e6-98cd-5170179ca250.png)
##### Filter Builder

![screen shot 2016-05-17 at 1 02 22 pm](https://cloud.githubusercontent.com/assets/5418735/15331929/95ea809c-1c31-11e6-9a24-1b7f62443605.png)
#### Tablet Screenshots
##### Patient List

![screen shot 2016-05-17 at 12 58 17 pm](https://cloud.githubusercontent.com/assets/5418735/15331817/12ea481c-1c31-11e6-947a-a5cbc047a912.png)
##### Patient View

![screen shot 2016-05-17 at 1 18 38 pm](https://cloud.githubusercontent.com/assets/5418735/15332013/fbaa6316-1c31-11e6-9810-592ce40aaff4.png)
##### Filter Builder

![screen shot 2016-05-17 at 1 00 59 pm](https://cloud.githubusercontent.com/assets/5418735/15331800/097873da-1c31-11e6-9409-00fbd69d0523.png)
