### PR TITLE
Filter Builder: Keep Sort Order for Searched Codes As-Is

### DIFF
--- a/app/mixins/condition-encounter-code-filters.js
+++ b/app/mixins/condition-encounter-code-filters.js
@@ -49,6 +49,9 @@ export default Ember.Mixin.create({
       matcher() {
         return true;
       },
+      sorter(items) {
+        return items;
+      },
       source(query, process) {
         let queryParams = {
           codesystem: self.get('selectedCodingSystem.system'),


### PR DESCRIPTION
When searching on code (for the filter builder) do not re-sort the codes.  The backend returns them in the desired sort order (which is by most-used first).
