### PR TITLE
Implemented Risk History Chart Click Feature that Updates Risk Plot

### DIFF
--- a/app/components/aster-plot-chart.js
+++ b/app/components/aster-plot-chart.js
@@ -28,6 +28,7 @@ export default Component.extend({
     g.append('g').classed('inner', true);
 
     this.updateChart();
+    this.selectedCategoryObserver();
   },
 
   selectedCategoryObserver: observer('selectedCategory', function selectedCategoryObserver() {

--- a/app/components/aster-plot-chart.js
+++ b/app/components/aster-plot-chart.js
@@ -30,6 +30,27 @@ export default Component.extend({
     this.updateChart();
   },
 
+  selectedCategoryObserver: observer('selectedCategory', function selectedCategoryObserver() {
+    let svg = d3.select(this.element).select('svg');
+
+    if (svg == null) {
+      return;
+    }
+
+    svg.selectAll('.category').classed('active', false);
+
+    let category = this.get('selectedCategory');
+    if (category != null) {
+      svg.selectAll(`.category${category.name.camelize().capitalize()}`).classed('active', true);
+    }
+  }),
+
+  tip: computed({
+    get() {
+      return d3.tip().attr('class', 'd3-tip').html((d) => `${d.data.name} : ${d.data.value}`);
+    }
+  }),
+
   updateChart: observer('data', function updateChart() {
     let svg = d3.select(this.element).select('svg');
     if (svg == null || !this.get('data')) {
@@ -49,16 +70,14 @@ export default Component.extend({
     let maxSliceRadius = 0.8 * radius;
 
     let selectCategory = (d) => {
-      svg.selectAll('.category').classed('active', false);
       if (this.get('selectedCategory') === d.data) {
         this.attrs.selectCategory(null);
       } else {
-        svg.selectAll(`.category${d.data.name.camelize().capitalize()}`).classed('active', true);
         this.attrs.selectCategory(d.data);
       }
     };
 
-    let tip = d3.tip().attr('class', 'd3-tip').html((d) => `${d.data.name} : ${d.data.value}`);
+    let tip = this.get('tip');
 
     svg.call(tip);
 

--- a/app/components/patient-risk-chart.js
+++ b/app/components/patient-risk-chart.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import C3Chart from 'ember-cli-c3/components/c3-chart';
 import moment from 'moment';
+import get from 'ember-metal/get';
 
 const { computed } = Ember;
 
@@ -41,6 +42,19 @@ export default C3Chart.extend({
       ],
       types: {
         risk: 'area-spline'
+      },
+      selection: {
+        enabled: true,
+        multiple: false
+      },
+      onselected: () => {
+        let index = get(this.get('chart').selected(), 'firstObject.index');
+        if (index != null) {
+          this.attrs.setSelectedRisk(data.objectAt(index));
+        }
+      },
+      onunselected: () => {
+        this.attrs.setSelectedRisk(null);
       }
     };
   }),
@@ -82,6 +96,9 @@ export default C3Chart.extend({
             expand: {
               r: 5.5
             }
+          },
+          select: {
+            r: 6.5
           }
         },
         size: {

--- a/app/components/patient-risk-chart.js
+++ b/app/components/patient-risk-chart.js
@@ -2,22 +2,35 @@ import Ember from 'ember';
 import C3Chart from 'ember-cli-c3/components/c3-chart';
 import moment from 'moment';
 import get from 'ember-metal/get';
+import run from 'ember-runloop';
 
 const { computed } = Ember;
 
 export default C3Chart.extend({
   classNames: ['patient-risk-chart'],
 
+  selectedRisk: null,
+
   offsetTime: 4,        // default time offset numeral
   offsetUnit: 'years',  // default time offset unit
-  height: 54,          // default height of chart
+  height: 54,           // default height of chart
 
-  data: computed('chartData.[]', 'offsetTime', 'offsetUnit', function() {
+  didInsertElement() {
+    this._super(...arguments);
+
+    this.get('chart').select(null, [this.get('filteredChartData.length') - 1]);
+  },
+
+  filteredChartData: computed('chartData.[]', 'offsetTime', 'offsetUnit', function filteredChartData() {
     let startDate = moment().subtract(this.get('offsetTime'), this.get('offsetUnit'));
 
-    let data = this.get('chartData').filter(function(datum) {
+    return this.get('chartData').filter(function(datum) {
       return !startDate.isAfter(datum.get('date'));
     });
+  }),
+
+  data: computed('filteredChartData.[]', function() {
+    let data = this.get('filteredChartData');
 
     // group data by dates
     let nestedData = d3.nest()
@@ -50,11 +63,23 @@ export default C3Chart.extend({
       onselected: () => {
         let index = get(this.get('chart').selected(), 'firstObject.index');
         if (index != null) {
-          this.attrs.setSelectedRisk(data.objectAt(index));
+          let selectedDataPoint = data.objectAt(index);
+          if (selectedDataPoint !== this.get('selectedRisk')) {
+            this.attrs.setSelectedRisk(selectedDataPoint);
+          }
         }
       },
       onunselected: () => {
-        this.attrs.setSelectedRisk(null);
+        run(() => this.attrs.setSelectedRisk(null));
+
+        run.later(() => {
+          if (this.get('chart').selected().length === 0) {
+            let index = this.get('filteredChartData').indexOf(this.get('selectedRisk'));
+            if (index !== -1) {
+              this.get('chart').select(null, [index]);
+            }
+          }
+        });
       }
     };
   }),

--- a/app/components/patient-summary.js
+++ b/app/components/patient-summary.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import service from 'ember-service/inject';
-import get from 'ember-metal/get';
 import PatientIconClassNames from '../mixins/patient-icon-class-names';
 
 export default Ember.Component.extend(PatientIconClassNames, {
@@ -29,17 +28,6 @@ export default Ember.Component.extend(PatientIconClassNames, {
     let risks = [birthRisk];
     risks.pushObjects(this.get('patient.sortedRisks'));
     return risks.filterBy('prediction.firstObject.outcome.displayText', currentAssessment);
-  }),
-
-  computedRisk: Ember.computed('patient.currentRisk', 'currentAssessment', function() {
-    let currentAssessment = this.get('currentAssessment');
-    let risks = this.get('patient.currentRisk');
-
-    if (currentAssessment && risks.length > 0) {
-      return get(risks.filterBy('key', currentAssessment), 'firstObject.value.value') || null;
-    }
-
-    return null;
   }),
 
   patientPhoto: Ember.computed.reads('patient.photo')

--- a/app/components/patient-summary.js
+++ b/app/components/patient-summary.js
@@ -9,6 +9,7 @@ export default Ember.Component.extend(PatientIconClassNames, {
 
   patient: null,
   currentAssessment: null,
+  selectedRisk: null,
   huddle: null,
   hasRisks: false,
 

--- a/app/components/patient-viewer.js
+++ b/app/components/patient-viewer.js
@@ -6,6 +6,7 @@ import { addCSSRule } from 'ember-on-fhir/utils/create-stylesheet';
 import { isTodayOrAfter } from 'ember-on-fhir/helpers/is-today-or-after';
 import moment from 'moment';
 import Pikaday from 'pikaday';
+import DS from 'ember-data';
 
 export default Component.extend(HasStylesheetMixin, {
   patient: null,
@@ -25,9 +26,11 @@ export default Component.extend(HasStylesheetMixin, {
     }
   }),
   selectedCategory: null,
+  oldCategoryName: null,
   nextScheduledHuddle: null,
   displayEditHuddleModal: false,
   displayClearDiscussedModal: false,
+  selectedPatientRisk: null,
 
   selectedScheduleDate: computed({
     get() {
@@ -147,13 +150,43 @@ export default Component.extend(HasStylesheetMixin, {
     }
   }),
 
-  slices: computed('currentAssessment', 'patientRisks.@each.pie', function() {
-    let patientRisks = this.get('patientRisks');
-    if (patientRisks.get('length') === 0) {
+  selectedPatientRiskOrLast: computed('selectedPatientRisk', 'patientRisks.lastObject', {
+    get() {
+      return this.get('selectedPatientRisk') || this.get('patientRisks.lastObject');
+    }
+  }),
+
+  pie: computed('currentAssessment', 'selectedPatientRiskOrLast', function pie() {
+    let selectedPatientRiskOrLast = this.get('selectedPatientRiskOrLast');
+
+    if (selectedPatientRiskOrLast == null) {
+      return null;
+    }
+
+    let promise = selectedPatientRiskOrLast.get('pie').then((pie) => {
+      let oldCategoryName = this.get('oldCategoryName');
+
+      if (oldCategoryName) {
+        let slices = pie.get('sliceArray');
+        let slice = slices.findBy('name', oldCategoryName);
+        this.attrs.selectCategory(slice);
+
+        this.set('oldCategoryName', null);
+      }
+
+      return pie;
+    });
+
+    return DS.PromiseObject.create({ promise });
+  }),
+
+  slices: computed('selectedPatientRiskOrLast', 'pie', 'pie.isFulfilled', function() {
+    let selectedPatientRiskOrLast = this.get('selectedPatientRiskOrLast');
+    if (selectedPatientRiskOrLast == null) {
       return [];
     }
 
-    return patientRisks.get('lastObject.pie.sliceArray');
+    return this.get('pie.sliceArray') || [];
   }),
 
   hasRisks: computed('patientRisks.length', 'naRiskAssessment', {
@@ -190,6 +223,13 @@ export default Component.extend(HasStylesheetMixin, {
     closeEditHuddleModal() {
       this.set('displayEditHuddleModal', false);
       this.attrs.refreshHuddles();
+    },
+
+    setSelectedRisk(risk) {
+      let selectedCategory = this.get('selectedCategory');
+      this.set('oldCategoryName', selectedCategory == null ? null : selectedCategory.name);
+      this.set('selectedPatientRisk', risk);
+      this.attrs.selectCategory(null);
     }
   }
 });

--- a/app/components/patient-viewer.js
+++ b/app/components/patient-viewer.js
@@ -144,7 +144,7 @@ export default Component.extend(HasStylesheetMixin, {
     }
   }),
 
-  patientRisks: computed('currentAssessment', 'patient.sortedRisks.[]', {
+  patientRisks: computed('patient', 'currentAssessment', 'patient.sortedRisks.[]', {
     get() {
       return this.get('patient.sortedRisks').filterBy('prediction.firstObject.outcome.displayText', this.get('currentAssessment'));
     }
@@ -156,7 +156,7 @@ export default Component.extend(HasStylesheetMixin, {
     }
   }),
 
-  pie: computed('currentAssessment', 'selectedPatientRiskOrLast', function pie() {
+  pie: computed('patient', 'currentAssessment', 'selectedPatientRiskOrLast', function pie() {
     let selectedPatientRiskOrLast = this.get('selectedPatientRiskOrLast');
 
     if (selectedPatientRiskOrLast == null) {

--- a/app/components/patient-viewer.js
+++ b/app/components/patient-viewer.js
@@ -150,7 +150,7 @@ export default Component.extend(HasStylesheetMixin, {
     }
   }),
 
-  selectedPatientRiskOrLast: computed('selectedPatientRisk', 'patientRisks.lastObject', {
+  selectedPatientRiskOrLast: computed('patient', 'currentAssessment', 'selectedPatientRisk', 'patientRisks.lastObject', {
     get() {
       return this.get('selectedPatientRisk') || this.get('patientRisks.lastObject');
     }

--- a/app/components/patient-viewer.js
+++ b/app/components/patient-viewer.js
@@ -180,6 +180,8 @@ export default Component.extend(HasStylesheetMixin, {
     return DS.PromiseObject.create({ promise });
   }),
 
+  pieIsLoading: computed.reads('pie.isPending'),
+
   slices: computed('selectedPatientRiskOrLast', 'pie', 'pie.isFulfilled', function() {
     let selectedPatientRiskOrLast = this.get('selectedPatientRiskOrLast');
     if (selectedPatientRiskOrLast == null) {
@@ -229,7 +231,6 @@ export default Component.extend(HasStylesheetMixin, {
       let selectedCategory = this.get('selectedCategory');
       this.set('oldCategoryName', selectedCategory == null ? null : selectedCategory.name);
       this.set('selectedPatientRisk', risk);
-      this.attrs.selectCategory(null);
     }
   }
 });

--- a/app/config/ember-spinner/large.js
+++ b/app/config/ember-spinner/large.js
@@ -1,0 +1,7 @@
+export default {
+  lines: 11,
+  length: 8,
+  width: 4,
+  radius: 8,
+  speed: 1
+};

--- a/app/controllers/patients/show.js
+++ b/app/controllers/patients/show.js
@@ -117,6 +117,10 @@ export default Controller.extend({
 
     unregisterPatientViewer() {
       this.set('patientViewerComponent', null);
+    },
+
+    nextPatient() {
+      this.set('selectedCategory', null);
     }
   }
 });

--- a/app/styles/_charts.scss
+++ b/app/styles/_charts.scss
@@ -23,3 +23,8 @@
     color: #333;
   }
 }
+
+.aster-plot-container {
+  min-height: 300px;
+  position: relative;
+}

--- a/app/styles/_charts.scss
+++ b/app/styles/_charts.scss
@@ -8,6 +8,15 @@
     stroke-width: 1px;
     stroke: white;
     fill: $brand-primary !important;
+
+    &._selected_ {
+      fill: $brand-danger !important;
+    }
+  }
+
+  .c3-selected-circle {
+    stroke-width: 0;
+    fill: $brand-danger !important;
   }
 
   .c3-tooltip {

--- a/app/styles/_patient-viewer.scss
+++ b/app/styles/_patient-viewer.scss
@@ -103,3 +103,9 @@
   left: 0;
   width:auto;
 }
+
+.current-risk-date {
+  text-align: center;
+  font-size: 18px;
+  padding-top: 1em;
+}

--- a/app/templates/components/patient-summary.hbs
+++ b/app/templates/components/patient-summary.hbs
@@ -42,7 +42,7 @@
 
       <div class="col-xs-5 patient-risk-chart">
         {{#if hasRisks}}
-          {{patient-risk-chart chartData=risksWithBirthdayStart}}
+          {{patient-risk-chart chartData=risksWithBirthdayStart setSelectedRisk=attrs.setSelectedRisk}}
         {{/if}}
       </div>
 

--- a/app/templates/components/patient-summary.hbs
+++ b/app/templates/components/patient-summary.hbs
@@ -42,7 +42,7 @@
 
       <div class="col-xs-5 patient-risk-chart">
         {{#if hasRisks}}
-          {{patient-risk-chart chartData=risksWithBirthdayStart setSelectedRisk=attrs.setSelectedRisk}}
+          {{patient-risk-chart chartData=risksWithBirthdayStart selectedRisk=selectedRisk setSelectedRisk=attrs.setSelectedRisk}}
         {{/if}}
       </div>
 

--- a/app/templates/components/patient-summary.hbs
+++ b/app/templates/components/patient-summary.hbs
@@ -47,9 +47,9 @@
       </div>
 
       <div class="col-xs-1">
-        {{#if computedRisk}}
+        {{#if selectedRisk}}
           <div class="patient-risk">
-            {{computedRisk}}
+            {{selectedRisk.value}}
           </div>
         {{/if}}
       </div>

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -1,5 +1,5 @@
 {{!------------------------- PATIENT SUMMARY --------------------------------}}
-{{patient-summary patient=patient currentAssessment=currentAssessment huddle=futureDisplayHuddle hasRisks=hasRisks setSelectedRisk=(action 'setSelectedRisk')}}
+{{patient-summary patient=patient currentAssessment=currentAssessment huddle=futureDisplayHuddle hasRisks=hasRisks setSelectedRisk=(action 'setSelectedRisk') selectedRisk=selectedPatientRiskOrLast}}
 
 {{!------------------------- PATIENT STATS ----------------------------------}}
 <div class="row">
@@ -98,39 +98,43 @@
 
         {{!--------------------- ASTER PLOT -------------------------------------}}
         <div class="aster-plot-container col-lg-6 col-md-5">
-          {{aster-plot-chart patient=patient data=slices selectedCategory=selectedCategory selectCategory=(action attrs.selectCategory)}}
-
-          {{!------------------- CATEGORY DETAILS -------------------------------}}
-          {{#if selectedCategory}}
-            {{category-details category=selectedCategory}}
+          {{#if pieIsLoading}}
+            {{ember-spinner config='large'}}
           {{else}}
-            <div class="category-details">
-              <div class="category-name">
-                {{currentAssessment}}
+            {{aster-plot-chart patient=patient data=slices selectedCategory=selectedCategory selectCategory=(action attrs.selectCategory)}}
+
+            {{!------------------- CATEGORY DETAILS -------------------------------}}
+            {{#if selectedCategory}}
+              {{category-details category=selectedCategory}}
+            {{else}}
+              <div class="category-details">
+                <div class="category-name">
+                  {{currentAssessment}}
+                </div>
+
+                <div class="category-stat row">
+                  <div class="category-stat-label col-md-2 col-sm-3">
+                    Risk:
+                  </div>
+
+                  <div class="col-lg-1 col-md-2 col-sm-2 col-xs-2 category-stat-value">
+                    {{selectedPatientRiskOrLast.value}}
+                  </div>
+
+                  <div class="col-lg-7 hidden-md hidden-sm col-xs-7">
+                    {{horizontal-bar-chart max=4 width=300 height=5 value=computedRisk}}
+                  </div>
+
+                  <div class="col-md-5 col-sm-5 hidden-lg hidden-xs">
+                    {{horizontal-bar-chart max=4 width=180 height=5 value=computedRisk}}
+                  </div>
+                </div>
+
+                <div class="sub-text">
+                  Choose category for more detail.
+                </div>
               </div>
-
-              <div class="category-stat row">
-                <div class="category-stat-label col-md-2 col-sm-3">
-                  Risk:
-                </div>
-
-                <div class="col-lg-1 col-md-2 col-sm-2 col-xs-2 category-stat-value">
-                  {{selectedPatientRiskOrLast.value}}
-                </div>
-
-                <div class="col-lg-7 hidden-md hidden-sm col-xs-7">
-                  {{horizontal-bar-chart max=4 width=300 height=5 value=computedRisk}}
-                </div>
-
-                <div class="col-md-5 col-sm-5 hidden-lg hidden-xs">
-                  {{horizontal-bar-chart max=4 width=180 height=5 value=computedRisk}}
-                </div>
-              </div>
-
-              <div class="sub-text">
-                Choose category for more detail.
-              </div>
-            </div>
+            {{/if}}
           {{/if}}
         </div>
 

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -1,5 +1,5 @@
 {{!------------------------- PATIENT SUMMARY --------------------------------}}
-{{patient-summary patient=patient currentAssessment=currentAssessment huddle=futureDisplayHuddle hasRisks=hasRisks}}
+{{patient-summary patient=patient currentAssessment=currentAssessment huddle=futureDisplayHuddle hasRisks=hasRisks setSelectedRisk=(action 'setSelectedRisk')}}
 
 {{!------------------------- PATIENT STATS ----------------------------------}}
 <div class="row">
@@ -115,7 +115,7 @@
                 </div>
 
                 <div class="col-lg-1 col-md-2 col-sm-2 col-xs-2 category-stat-value">
-                  {{computedRisk}}
+                  {{selectedPatientRiskOrLast.value}}
                 </div>
 
                 <div class="col-lg-7 hidden-md hidden-sm col-xs-7">

--- a/app/templates/components/patient-viewer.hbs
+++ b/app/templates/components/patient-viewer.hbs
@@ -98,6 +98,10 @@
 
         {{!--------------------- ASTER PLOT -------------------------------------}}
         <div class="aster-plot-container col-lg-6 col-md-5">
+          <div class="current-risk-date">
+            {{moment-format selectedPatientRiskOrLast.date 'll'}}
+          </div>
+
           {{#if pieIsLoading}}
             {{ember-spinner config='large'}}
           {{else}}

--- a/app/templates/patients/show.hbs
+++ b/app/templates/patients/show.hbs
@@ -5,7 +5,8 @@
         {{#link-to 'patients.index'}}<i class="fa fa-chevron-left"></i>  Back to Patient List{{/link-to}}
         <div class="pull-right">
           {{#if huddlePatients}}
-            {{currentPatientIndex}} / {{huddleCount}} {{#link-to 'patients.show' nextPatient}} <i class="fa fa-chevron-right"></i> {{/link-to}}
+            {{currentPatientIndex}} / {{huddleCount}}
+            {{#link-to 'patients.show' nextPatient invokeAction=(action 'nextPatient')}}<i class="fa fa-chevron-right"></i>{{/link-to}}
           {{/if}}
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-drag-drop": "pgrippi/ember-drag-drop#master",
     "ember-export-application-global": "1.0.5",
     "ember-fhir-adapter": "0.0.12",
+    "ember-link-action": "0.0.34",
     "ember-load-initializers": "0.5.1",
     "ember-modal-dialog": "0.8.3",
     "ember-moment": "6.1.0",


### PR DESCRIPTION
# Implemented Risk History Chart Click Feature that Updates Risk Plot
- Implemented feature where clicking on a risk history plot point will update the aster plot to the same day. Clicking was used as opposed to hovering so that categories could be selected and compared.
- Unclicking a selected plot point will default back to the most recent plot point on the far right.
- Styled.
#### TODO
- [ ] Fix bug where left and right plot points get cut off when chart is small.
#### Video

![risk-chart-click](https://cloud.githubusercontent.com/assets/5418735/15871999/45eb6cb0-2cc5-11e6-9b3c-29e67bbf144d.gif)
