### PR TITLE
Unique Conditions and Medications

### DIFF
--- a/app/helpers/uniqBy.js
+++ b/app/helpers/uniqBy.js
@@ -1,0 +1,18 @@
+import { helper } from 'ember-helper';
+import Ember from 'ember';
+
+export function uniqBy(array, by) {
+  let ret = Ember.A();
+  let seen = {};
+
+  array.forEach((item) => {
+      let guid = item.get(by);
+      if (!(guid in seen)) {
+        seen[guid] = true;
+        ret.push(item);
+      }
+    });
+  return ret;
+}
+
+export default helper(uniqBy);

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import Patient from 'ember-fhir-adapter/models/patient';
+import { uniqBy } from '../helpers/uniqBy';
 import moment from 'moment';
 
 export default Patient.extend({
@@ -99,8 +100,16 @@ export default Patient.extend({
     return med.isActive('endDate');
   }),
 
+  uniqueActiveMedications: Ember.computed('activeMedications', function() {
+    return uniqBy(this.get('activeMedications').toArray(), 'displayText');
+  }),
+
   activeConditions: Ember.computed.filter('conditions', function(cond) {
     return cond.isActive('endDate') && cond.get('verificationStatus') === 'confirmed';
+  }),
+
+  uniqueActiveConditions: Ember.computed('activeConditions', function() {
+    return uniqBy(this.get('activeConditions').toArray(), 'displayText');
   }),
 
   futureAppointments: Ember.computed.filter('appointments', function(appointment) {

--- a/app/templates/components/patient-stats.hbs
+++ b/app/templates/components/patient-stats.hbs
@@ -40,7 +40,7 @@
   <div class="collapse-panel-title">
     <a data-toggle="collapse" href="#conditions" aria-expanded="true" aria-controls="collapseOne">
       <i class="icon-med-clipboard"></i>
-      Conditions ({{patient.activeConditions.length}})
+      Conditions ({{patient.uniqueActiveConditions.length}})
       <i class="fa fa-chevron-down pull-right"></i>
     </a>
   </div>
@@ -48,7 +48,7 @@
 <div class="panel-body">
   <div class="collapse in" id="conditions">
     <ul>
-      {{#each patient.activeConditions as |condition|}}
+      {{#each patient.uniqueActiveConditions as |condition|}}
         {{#if condition.code}}
           <li>{{condition.code.displayText}}</li>
         {{/if}}
@@ -61,7 +61,7 @@
   <div class="collapse-panel-title">
     <a data-toggle="collapse" href="#medications" aria-expanded="true" aria-controls="collapseOne">
       <i class="icon-medication"></i>
-      Medications ({{patient.activeMedications.length}})
+      Medications ({{patient.uniqueActiveMedications.length}})
       <i class="fa fa-chevron-down pull-right"></i>
     </a>
   </div>
@@ -69,7 +69,7 @@
 <div class="panel-body">
   <div class="collapse in" id="medications">
     <ul>
-      {{#each patient.activeMedications as |medication|}}
+      {{#each patient.uniqueActiveMedications as |medication|}}
         {{#if medication.displayText}}
           <li>{{medication.displayText}}</li>
         {{/if}}


### PR DESCRIPTION
In patient summary unique the conditions and meds by their display names to minimize duplicates displayed to users

Why does Ember not have a uniqBy function on Array? It does, but it wasn't added until, I don't know because accessing old documentation is apparently not a desired use case of the website. (includes LTS release documentation)
