### PR TITLE
Human Readable Code Display

### DIFF
--- a/app/models/codeable-concept.js
+++ b/app/models/codeable-concept.js
@@ -1,6 +1,17 @@
 import CodeableConcept from 'ember-fhir-adapter/models/codeable-concept';
 import computed from 'ember-computed';
 
+// We don't want to display the URI of the system, it's ugly, so here's a lookup table
+// TODO the better way to do this would be have it hucked in some config file.
+const SYSTEM_LOOKUP = {
+  'http://snomed.info/sct': 'SNOMED',
+  'http://www.nlm.nih.gov/research/umls/rxnorm': 'RxNorm',
+  'http://loinc.org': 'LOINC',
+  'http://www.ama-assn.org/go/cpt': 'CPT',
+  'http://hl7.org/fhir/sid/icd-9': 'ICD9',
+  'http://hl7.org/fhir/sid/icd-10': 'ICD10'
+};
+
 export default CodeableConcept.extend({
   hasCode(code) {
     let matchedCodes = this.get('coding').map(function(c) {
@@ -11,7 +22,7 @@ export default CodeableConcept.extend({
 
   displayText: computed('text', 'coding.firstObject.display', 'coding.firstObject.system', 'coding.firstObject.code', {
     get() {
-      return this.get('text') || this.get('coding.firstObject.display') || `${this.get('coding.firstObject.system')}-${this.get('coding.firstObject.code')}`;
+      return this.get('text') || this.get('coding.firstObject.display') || `${SYSTEM_LOOKUP[this.get('coding.firstObject.system')] || this.get('coding.firstObject.system')} ${this.get('coding.firstObject.code')}`;
     }
   }).readOnly()
 });

--- a/tests/unit/models/codeable-concept-test.js
+++ b/tests/unit/models/codeable-concept-test.js
@@ -1,0 +1,43 @@
+import { moduleForModel, test } from 'ember-qunit';
+import run from 'ember-runloop';
+
+moduleForModel('codeable-concept', 'Unit | Model | codeable-concept', {
+  // Specify the other units that are required for this test.
+  needs: ['model:identifier', 'model:codeable-concept',
+        'model:location', 'model:period', 'model:coding',
+        'model:reference', 'model:quantity', 'model:range',
+        'model:condition-stage-component',
+        'model:condition-evidence-component']
+});
+
+test('a codeable-concept.coding with a display has the correct displayText', function(assert) {
+  let model = this.subject();
+  let store = this.store();
+  run(() => {
+    let coding = store.createRecord('coding', {
+      'system': 'http://www.ama-assn.org/go/cpt',
+      'code': '99201',
+      'display': 'Outpatient Encounter'
+    });
+    model.get('coding').pushObject(coding);
+    assert.equal(model.get('displayText'), 'Outpatient Encounter');
+  });
+});
+
+test('a codeable-concept with a text has the correct displayText', function(assert) {
+  let model = this.subject({ 'text': 'My Encounter' });
+  assert.equal(model.get('displayText'), 'My Encounter');
+});
+
+test('a codeable-concept.coding without a display has the correct displayText', function(assert) {
+  let model = this.subject();
+  let store = this.store();
+  run(() => {
+    let coding = store.createRecord('coding', {
+      'system': 'http://www.ama-assn.org/go/cpt',
+      'code': '99201'
+    });
+    model.get('coding').pushObject(coding);
+    assert.equal(model.get('displayText'), 'CPT 99201');
+  });
+});


### PR DESCRIPTION
Display human readable text for code systems if it's a common one.

Code will now display like 

`ICD9 12345` instead of `http://hl7.org/fhir/sid/icd-9-12345`
