### PR TITLE
Timeline Cleanup

### DIFF
--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -45,34 +45,21 @@ export default Patient.extend({
     let events =  Ember.A([]);
 
     this.get('encounters').map(function(e) {
-      let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'encounter' });
+      let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'encounter',  isEnd: e.hasOccured('endDate') });
       events.push(patientEvent);
-
-      if (e.hasOccured('endDate')) {
-        let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'encounter', isEnd: true });
-        events.push(patientEvent);
-      }
     });
 
     this.get('conditions').map(function(e) {
       if (e.get('verificationStatus') === 'confirmed') {
-        let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'condition' });
+        let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'condition',  isEnd: e.hasOccured('endDate') });
         events.push(patientEvent);
 
-        if (e.hasOccured('endDate')) {
-          let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'condition', isEnd: true });
-          events.push(patientEvent);
-        }
       }
     });
 
     this.get('medications').map(function(e) {
-      let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'medication' });
+      let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'medication',  isEnd: e.hasOccured('endDate') });
       events.push(patientEvent);
-      if (e.hasOccured('endDate')) {
-        let patientEvent = e.store.createRecord('patient-event', { event: e, type: 'medication', isEnd: true });
-        events.push(patientEvent);
-      }
     });
 
     this.get('risksByOutcome').map(function(outcome) {
@@ -93,7 +80,7 @@ export default Patient.extend({
       events.push(...riskTransitions.filter((e) => e.get('deltaRisk') !== 0));
     });
 
-    return events.sortBy('effectiveDate').reverse();
+    return events.sortBy('event.startDate').reverse();
   }),
 
   activeMedications: Ember.computed.filter('medications', function(med) {

--- a/app/templates/components/timeline-event.hbs
+++ b/app/templates/components/timeline-event.hbs
@@ -1,13 +1,18 @@
 <div class="timeline-event {{eventClass}}">
   <div class="timeline-event-text">
     {{event.displayText}}
-    {{#if event.isEnd}}
-    (End)
-    {{/if}}
+    
   </div>
 
   <div class="timeline-event-start-date">
-    {{moment-format event.effectiveDate 'lll'}}
+    {{#if event.event.startDate}}
+      {{moment-format event.event.startDate 'lll'}} 
+      {{#if event.isEnd}}
+        - {{moment-format event.event.endDate 'lll'}}
+      {{/if}}
+    {{else}}
+      Unknown Date
+    {{/if}}
   </div>
 
   <div class="timeline-event-icon">


### PR DESCRIPTION
- Remove end events to declutter timeline
- Make dates appear as start-end for events with end dates
- Sort by startDate
- If no startDate specified replace with 'Unknown Date' text.

<img width="531" alt="screen shot 2016-08-09 at 10 18 04 am" src="https://cloud.githubusercontent.com/assets/329127/17519541/561f6f4c-5e1a-11e6-90ba-ede7e606a463.png">
