### PR TITLE
Fix Patient Nav Links

### DIFF
--- a/app/routes/patients/index.js
+++ b/app/routes/patients/index.js
@@ -16,6 +16,17 @@ export default Route.extend(AuthenticatedRouteMixin, PaginatedRouteMixin, {
   perPage: 8,
   huddle: null,
 
+  activate() {
+    let controller = this.controllerFor('patients.show');
+    if (controller.get('huddlePatients')) {
+      // Ember controllers are singletons, this means when we overwrite the computed property we lose being able to compute it.
+      // If we have the controller set up when we activate THIS route we want to reset that computed property.
+      controller.set('currentPatientIndex',  Ember.computed('huddlePatients', 'model', function() {
+        return this.get('huddlePatients').indexOf(this.get('model')) + 1 + this.get('huddleOffset');
+      }));
+    }
+  },
+
   beforeModel(transition) {
     let huddleId = get(transition, 'queryParams.huddleId');
     if (huddleId) {

--- a/app/routes/patients/show.js
+++ b/app/routes/patients/show.js
@@ -11,11 +11,6 @@ export default Route.extend({
   },
 
   afterModel(model/*, transition */) {
-    let controller = this.controllerFor('patients.show');
-    if (controller.get('huddlePatients')) {
-      let patientIndex = controller.get('huddlePatients').indexOf(model) + 1 + controller.get('huddleOffset');
-      controller.set('currentPatientIndex', patientIndex);
-    }
     return this.get('ajax').request('/Group', {
       data: {
         code: 'http://interventionengine.org/fhir/cs/huddle|HUDDLE',


### PR DESCRIPTION
Reset the route properly to handle transitions over the page boundaries.

![select animation](https://cloud.githubusercontent.com/assets/329127/17530950/c4de48fe-5e47-11e6-8f19-4f4eee66b0f4.gif)
