### PR TITLE
Empty Huddle Fix

### DIFF
--- a/app/controllers/patients/index.js
+++ b/app/controllers/patients/index.js
@@ -81,10 +81,12 @@ export default Controller.extend({
   refetch() {
     run(() => {
       this.set('page', 1);
+      let groupIds = [this.get('huddleId'), this.get('groupId')].filter((n) => n);
+
       let patientsRemoteArray = this.get('model.patients');
       patientsRemoteArray.set('sortBy', this.get('sortBy'));
       patientsRemoteArray.set('sortDescending', this.get('sortDescending'));
-      patientsRemoteArray.set('groupId', this.get('huddleId') || this.get('groupId'));
+      patientsRemoteArray.set('groupId', groupIds);
       // patientsRemoteArray.set('patientIds', this.get('huddlePatientIds'));
       patientsRemoteArray.set('patientSearch', this.get('patientSearch'));
       patientsRemoteArray.set('page', 1);

--- a/app/controllers/patients/index.js
+++ b/app/controllers/patients/index.js
@@ -84,8 +84,8 @@ export default Controller.extend({
       let patientsRemoteArray = this.get('model.patients');
       patientsRemoteArray.set('sortBy', this.get('sortBy'));
       patientsRemoteArray.set('sortDescending', this.get('sortDescending'));
-      patientsRemoteArray.set('groupId', this.get('groupId'));
-      patientsRemoteArray.set('patientIds', this.get('huddlePatientIds'));
+      patientsRemoteArray.set('groupId', this.get('huddleId') || this.get('groupId'));
+      // patientsRemoteArray.set('patientIds', this.get('huddlePatientIds'));
       patientsRemoteArray.set('patientSearch', this.get('patientSearch'));
       patientsRemoteArray.set('page', 1);
       patientsRemoteArray.pageChanged();

--- a/app/routes/patients/index.js
+++ b/app/routes/patients/index.js
@@ -1,15 +1,14 @@
 import Ember from 'ember';
 import Route from 'ember-route';
 import service from 'ember-service/inject';
-import get from 'ember-metal/get';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import UnuthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 import PaginatedRouteMixin from 'ember-cli-pagination/remote/route-mixin';
 import FHIRPagedRemoteArray from '../../utils/fhir-paged-remote-array';
 import { parseHuddles } from 'ember-on-fhir/models/huddle';
 
 const { RSVP } = Ember;
 
-export default Route.extend(AuthenticatedRouteMixin, PaginatedRouteMixin, {
+export default Route.extend(UnuthenticatedRouteMixin, PaginatedRouteMixin, {
   store: service(),
   ajax: service(),
 
@@ -27,14 +26,6 @@ export default Route.extend(AuthenticatedRouteMixin, PaginatedRouteMixin, {
     }
   },
 
-  beforeModel(transition) {
-    let huddleId = get(transition, 'queryParams.huddleId');
-    if (huddleId) {
-      return this.get('ajax').request(`/Group/${huddleId}`).then((response) => {
-        this.set('huddle', parseHuddles(response));
-      });
-    }
-  },
 
   model(params) {
     let paramMapping = {
@@ -44,11 +35,7 @@ export default Route.extend(AuthenticatedRouteMixin, PaginatedRouteMixin, {
 
     let store = this.get('store');
     let perPage = this.get('perPage');
-    let groupIds = this.groupId;
-
-    if (params.huddleId && params.groupId) {
-      groupIds = [params.huddleId, params.groupId];
-    }
+    let groupIds = [params.huddleId, params.groupId].filter((n) => n);
 
     Ember.$.ajaxSetup({ traditional: true });
     return RSVP.hash({

--- a/app/routes/patients/index.js
+++ b/app/routes/patients/index.js
@@ -44,12 +44,13 @@ export default Route.extend(AuthenticatedRouteMixin, PaginatedRouteMixin, {
 
     let store = this.get('store');
     let perPage = this.get('perPage');
-    let patientIds = [];
+    let groupIds = this.groupId;
 
-    if (params.huddleId) {
-      patientIds = this.get('huddle.patients').mapBy('patientId');
+    if (params.huddleId && params.groupId) {
+      groupIds = [params.huddleId, params.groupId];
     }
 
+    Ember.$.ajaxSetup({ traditional: true });
     return RSVP.hash({
       // patients: store.findAll('patient'),
       patients: FHIRPagedRemoteArray.create({
@@ -60,10 +61,9 @@ export default Route.extend(AuthenticatedRouteMixin, PaginatedRouteMixin, {
         paramMapping,
         sortBy: params.sortBy || 'family',
         sortDescending: params.sortDescending,
-        groupId: params.groupId,
-        patientIds
+        groupId: groupIds
       }),
-      groups: store.findAll('group'),
+      groups: store.query('group', { actual: false }),
       huddles: this.get('ajax').request('/Group', { data: { code: 'http://interventionengine.org/fhir/cs/huddle|HUDDLE' } }).then((response) => parseHuddles(response.entry || []))
       // risks: store.findAll('risk'),
       // notificationCounts: store.findAll('notification-count')

--- a/app/routes/patients/index.js
+++ b/app/routes/patients/index.js
@@ -26,7 +26,6 @@ export default Route.extend(UnuthenticatedRouteMixin, PaginatedRouteMixin, {
     }
   },
 
-
   model(params) {
     let paramMapping = {
       page: '_offset',


### PR DESCRIPTION
- Fix query for empty huddles to use groupID instead of partientIDs
- Also fix query for population to use actual:false instead of iterating through them and filtering.
