### PR TITLE
Rename CARRYOVER to ROLL_OVER

### DIFF
--- a/app/components/huddle-reason-icon.js
+++ b/app/components/huddle-reason-icon.js
@@ -37,7 +37,7 @@ export default Component.extend({
   reasonIconClass: computed('huddlePatient.reason', {
     get() {
       switch (this.get('huddlePatient.reason')) {
-        case REASON_CODES.CARRYOVER:
+        case REASON_CODES.ROLL_OVER:
           return 'fa fa-fw fa-arrow-circle-o-right';
         case REASON_CODES.MANUAL_ADDITION:
           return 'fa fa-fw fa-pencil';

--- a/app/models/huddle-patient.js
+++ b/app/models/huddle-patient.js
@@ -4,7 +4,7 @@ import { isEmpty } from 'ember-utils';
 import moment from 'moment';
 
 export const REASON_CODES = {
-  CARRYOVER: 'CARRYOVER',
+  ROLL_OVER: 'ROLL_OVER',
   MANUAL_ADDITION: 'MANUAL_ADDITION',
   RECENT_ENCOUNTER: 'RECENT_ENCOUNTER',
   RISK_SCORE: 'RISK_SCORE'


### PR DESCRIPTION
The backend renamed the code for when a patient is rolled over from an old huddle to a new huddle.  The new code is `ROLL_OVER`.  This PR address the change in the UI.

![image](https://cloud.githubusercontent.com/assets/2278253/18216671/42e2c5b8-7126-11e6-82b0-58744c35f08c.png)
